### PR TITLE
Test correctness of admm

### DIFF
--- a/dask_glm/logistic.py
+++ b/dask_glm/logistic.py
@@ -336,7 +336,7 @@ def admm(X, y, lamduh=0.1, rho=1, over_relax=1,
             print("Converged!", k)
             break
 
-    return z.mean(0)
+    return z
 
 
 # TODO: Dask+Numba JIT

--- a/dask_glm/tests/test_logistic.py
+++ b/dask_glm/tests/test_logistic.py
@@ -4,8 +4,8 @@ from dask import persist
 import numpy as np
 import dask.array as da
 
-from dask_glm.logistic import newton, bfgs, proximal_grad,\
-    gradient_descent
+from dask_glm.logistic import (newton, bfgs, proximal_grad,
+                               gradient_descent, admm)
 from dask_glm.utils import sigmoid, make_y
 
 
@@ -52,6 +52,7 @@ def test_methods(N, p, seed, opt):
     (gradient_descent, {'tol': 1e-7}),
     (proximal_grad, {'tol': 1e-6, 'reg': 'l1', 'lamduh': 0.001}),
     (proximal_grad, {'tol': 1e-7, 'reg': 'l2', 'lamduh': 0.001}),
+    (admm, {}),
 ])
 @pytest.mark.parametrize('N', [10000, 100000])
 @pytest.mark.parametrize('nchunks', [1, 10])


### PR DESCRIPTION
I went through ADMM for performance reasons but this algorithm seemed fine as is.  Apparently this has very little data transfer, so no persist magic seemed to be useful.  

On profiling I did find that `exp` issues were pretty serious here (see #23). 

I also extended the existing super-test to include admm and fixed the output

cc @moody-marlin 