### PR TITLE
Parallelize stepsize computation

### DIFF
--- a/dask_glm/logistic.py
+++ b/dask_glm/logistic.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from dask import delayed, persist, compute
-from time import sleep
 import numpy as np
 import dask.array as da
 from scipy.optimize import fmin_l_bfgs_b
@@ -186,7 +185,7 @@ def gradient_descent(X, y, max_steps=100, tol=1e-14):
 
         stepSize, lf, func, gradient = compute(stepSize, lf, func, gradient)
 
-        beta = beta - stepSize * gradient # tiny bit of repeat work here to avoid communication
+        beta = beta - stepSize * gradient  # tiny bit of repeat work here to avoid communication
         Xbeta = Xbeta - stepSize * Xgradient
 
         if stepSize == 0:

--- a/dask_glm/logistic.py
+++ b/dask_glm/logistic.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from dask import delayed, persist, compute
+from time import sleep
 import numpy as np
 import dask.array as da
 from scipy.optimize import fmin_l_bfgs_b
@@ -95,15 +96,13 @@ def bfgs(X, y, max_iter=500, tol=1e-14):
     return beta
 
 
-@jit(nogil=True)
 def loglike(Xbeta, y):
     #        # This prevents overflow
     #        if np.all(Xbeta < 700):
-    eXbeta = np.exp(Xbeta)
-    return np.sum(np.log1p(eXbeta)) - np.dot(y, Xbeta)
+    eXbeta = exp(Xbeta)
+    return log1p(eXbeta).sum() - dot(y, Xbeta)
 
 
-@jit(nogil=True)
 def compute_stepsize(beta, step, Xbeta, Xstep, y, curr_val, stepSize=1.0,
                      armijoMult=0.1, backtrackMult=0.1):
     obeta, oXbeta = beta, Xbeta
@@ -126,6 +125,31 @@ def compute_stepsize(beta, step, Xbeta, Xstep, y, curr_val, stepSize=1.0,
     return stepSize, beta, Xbeta, func
 
 
+def compute_stepsize_dask(beta, step, Xbeta, Xstep, y, curr_val, stepSize=1.0,
+                          armijoMult=0.1, backtrackMult=0.1):
+    beta, step, Xbeta, Xstep, y, curr_val = persist(beta, step, Xbeta, Xstep, y, curr_val)
+    obeta, oXbeta = beta, Xbeta
+    (steplen,) = compute((step ** 2).sum())
+    lf = curr_val
+    func = 0
+    for ii in range(100):
+        beta = obeta - stepSize * step
+        if ii and compute((beta == obeta).all())[0]:
+            stepSize = 0
+            break
+
+        Xbeta = oXbeta - stepSize * Xstep
+        func = loglike(Xbeta, y)
+        Xbeta, func = persist(Xbeta, func)
+
+        df = lf - compute(func)[0]
+        if df >= armijoMult * stepSize * steplen:
+            break
+        stepSize *= backtrackMult
+
+    return stepSize, beta, Xbeta, func
+
+
 def gradient_descent(X, y, max_steps=100, tol=1e-14):
     '''Michael Grant's implementation of Gradient Descent.'''
 
@@ -138,7 +162,6 @@ def gradient_descent(X, y, max_steps=100, tol=1e-14):
     recalcRate = 10
     backtrackMult = firstBacktrackMult
     beta = np.zeros(p)
-    y_local = y.compute()
 
     for k in range(max_steps):
         # how necessary is this recalculation?
@@ -153,12 +176,12 @@ def gradient_descent(X, y, max_steps=100, tol=1e-14):
 
         # backtracking line search
         lf = func
-        stepSize, _, _, func = delayed(compute_stepsize, nout=4)(beta, gradient,
-                                                Xbeta, Xgradient,
-                                                y, func,
-                                                backtrackMult=backtrackMult,
-                                                armijoMult=armijoMult,
-                                                stepSize=stepSize)
+        stepSize, _, _, func = compute_stepsize_dask(beta, gradient,
+                                                     Xbeta, Xgradient,
+                                                     y, func,
+                                                     backtrackMult=backtrackMult,
+                                                     armijoMult=armijoMult,
+                                                     stepSize=stepSize)
 
         beta, stepSize, Xbeta, gradient, lf, func, gradient, Xgradient = persist(
             beta, stepSize, Xbeta, gradient, lf, func, gradient, Xgradient)
@@ -167,7 +190,6 @@ def gradient_descent(X, y, max_steps=100, tol=1e-14):
 
         beta = beta - stepSize * gradient # tiny bit of repeat work here to avoid communication
         Xbeta = Xbeta - stepSize * Xgradient
-
 
         if stepSize == 0:
             print('No more progress')


### PR DESCRIPTION
Previously computation time in gradient descent was blocked by the sequential stepsize calculation.  It turns out that parallelizing this isn't that bad, at least not when latency to the cluster is low.

Sequential version plot: https://cdn.rawgit.com/mrocklin/163be5f81a446931e49d4382e6ae720f/raw/57156dd63720f57b471e036f7e94ee6ff8a8d6d0/dask-glm-stepsize-sequential.html

Parallel version plot: https://cdn.rawgit.com/mrocklin/163be5f81a446931e49d4382e6ae720f/raw/63ac2ff2e4bc917be4d8e8fa6d1cf4736e98217a/dask-glm-stepsize-parallel.html

Speedups on a simple problem are around 30%

(note, both commits here are valuable for git history, recommend rebase-and-merge)

cc @moody-marlin 