### PR TITLE
Regularizer class

### DIFF
--- a/dask_glm.yml
+++ b/dask_glm.yml
@@ -1,0 +1,29 @@
+name: dask_glm
+channels:
+- defaults
+dependencies:
+- mkl=2017.0.1=0
+- numpy=1.12.0=py35_0
+- openssl=1.0.2k=0
+- pandas=0.19.2=np112py35_1
+- pip=9.0.1=py35_1
+- python=3.5.2=0
+- python-dateutil=2.6.0=py35_0
+- pytz=2016.10=py35_0
+- readline=6.2=2
+- setuptools=27.2.0=py35_0
+- six=1.10.0=py35_0
+- sqlite=3.13.0=0
+- tk=8.5.18=0
+- toolz=0.8.2=py35_0
+- wheel=0.29.0=py35_0
+- xz=5.2.2=1
+- zlib=1.2.8=3
+- pip:
+  - cloudpickle==0.2.2
+  - "git+https://github.com/dask/dask.git"
+  - "git+https://github.com/dask/dask-glm.git"
+  - multipledispatch==0.4.9
+  - py==1.4.32
+  - pytest==3.0.6
+  - scipy==0.18.1

--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -7,9 +7,9 @@ import dask.array as da
 from scipy.optimize import fmin_l_bfgs_b
 
 
-from dask_glm.utils import dot, exp, log1p, absolute, sign
+from dask_glm.utils import dot, exp, log1p
 from dask_glm.families import Logistic
-from dask_glm.regularizers import L1, L2
+from dask_glm.regularizers import L1
 
 
 def compute_stepsize_dask(beta, step, Xbeta, Xstep, y, curr_val,

--- a/dask_glm/regularizers.py
+++ b/dask_glm/regularizers.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+
+
+class L2(object):
+
+    @staticmethod
+    def proximal_operator(beta, t):
+        return 1 / (1 + t) * beta
+
+    @staticmethod
+    def hessian(beta):
+        return 2 * np.eye(len(beta))
+
+    @staticmethod
+    def add_reg_hessian(hess, lam):
+        def wrapped(beta, *args):
+            return hess(beta, *args) + lam * L2.hessian(beta)
+        return wrapped
+
+    @staticmethod
+    def f(beta):
+        return (beta**2).sum()
+
+    @staticmethod
+    def add_reg_f(f, lam):
+        def wrapped(beta, *args):
+            return f(beta, *args) + lam * L2.f(beta)
+        return wrapped
+
+    @staticmethod
+    def gradient(beta):
+        return 2 * beta
+
+    @staticmethod
+    def add_reg_grad(grad, lam):
+        def wrapped(beta, *args):
+            return grad(beta, *args) + lam * L2.gradient(beta)
+        return wrapped
+
+
+class L1(object):
+
+    @staticmethod
+    def proximal_operator(beta, t):
+        z = np.maximum(0, beta - t) - np.maximum(0, -beta - t)
+        return z
+
+    @staticmethod
+    def hessian(beta):
+        raise ValueError('l1 norm is not twice differentiable!')
+
+    @staticmethod
+    def add_reg_hessian(hess, lam):
+        def wrapped(beta, *args):
+            return hess(beta, *args) + lam * L1.hessian(beta)
+        return wrapped
+
+    @staticmethod
+    def f(beta):
+        return (np.abs(beta)).sum()
+
+    @staticmethod
+    def add_reg_f(f, lam):
+        def wrapped(beta, *args):
+            return f(beta, *args) + lam * L1.f(beta)
+        return wrapped
+
+    @staticmethod
+    def gradient(beta):
+        if np.any(np.isclose(beta, 0)):
+            raise ValueError('l1 norm is not differentiable at 0!')
+        else:
+            return np.sign(beta)
+
+    @staticmethod
+    def add_reg_grad(grad, lam):
+        def wrapped(beta, *args):
+            return grad(beta, *args) + lam * L1.gradient(beta)
+        return wrapped

--- a/dask_glm/tests/test_admm.py
+++ b/dask_glm/tests/test_admm.py
@@ -5,6 +5,8 @@ import dask.array as da
 import numpy as np
 
 from dask_glm.algorithms import admm, local_update
+from dask_glm.families import Logistic, Normal
+from dask_glm.regularizers import L1
 from dask_glm.utils import make_y
 
 
@@ -13,15 +15,30 @@ from dask_glm.utils import make_y
                          [np.array([-1.5, 3]),
                           np.array([35, 2, 0, -3.2]),
                           np.array([-1e-2, 1e-4, 1.0, 2e-3, -1.2])])
-def test_local_update(N, beta):
+@pytest.mark.parametrize('family', [Logistic, Normal])
+def test_local_update(N, beta, family):
     M = beta.shape[0]
     X = np.random.random((N, M))
     y = np.random.random(N) > 0.4
     u = np.zeros(M)
     z = np.random.random(M)
-    rho = 1e6
+    rho = 1e7
 
-    result = local_update(X, y, beta, z, u, rho)
+    def create_local_gradient(func):
+        def wrapped(beta, X, y, z, u, rho):
+            return func(beta, X, y) + rho * (beta - z + u)
+        return wrapped
+
+    def create_local_f(func):
+        def wrapped(beta, X, y, z, u, rho):
+            return func(beta, X, y) + (rho / 2) * np.dot(beta - z + u,
+                                                         beta - z + u)
+        return wrapped
+
+    f = create_local_f(family.pointwise_loss)
+    fprime = create_local_gradient(family.pointwise_gradient)
+
+    result = local_update(X, y, beta, z, u, rho, f=f, fprime=fprime)
 
     assert np.allclose(result, z, atol=2e-3)
 
@@ -35,6 +52,6 @@ def test_admm_with_large_lamduh(N, p, nchunks):
     y = make_y(X, beta=np.array(beta), chunks=(N // nchunks,))
 
     X, y = persist(X, y)
-    z = admm(X, y, lamduh=1e4, rho=20, max_iter=500)
+    z = admm(X, y, reg=L1, lamduh=1e4, rho=20, max_iter=500)
 
     assert np.allclose(z, np.zeros(p), atol=1e-4)


### PR DESCRIPTION
Abstract the regularizers into classes for easy adjustments later. The names of the methods might need some adjustments but this wlll also allow us to easily use all methods for any regularizer -- example, if we wrap the gradient and hessian with L2, we can run newtons method for L2-regularized problems.

(Sorry @mrocklin , I couldn't help myself doing this before the API!)