### PR TITLE
API: Sketch out Estimator API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ wheels/
 .installed.cfg
 *.egg
 dask_glm/.ropeproject/*
+.ipynb_checkpoints/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n test-environment -c conda-forge python=$PYTHON numpy flake8 pytest scipy multipledispatch cloudpickle numba dask mock
+  - conda create -n test-environment -c conda-forge python=$PYTHON numpy flake8 pytest scipy multipledispatch cloudpickle numba dask mock scikit-learn
   - source activate test-environment
   - pip install git+https://github.com/dask/dask
 

--- a/dask_glm/datasets.py
+++ b/dask_glm/datasets.py
@@ -1,0 +1,24 @@
+import numpy as np
+import dask.array as da
+
+
+def make_classification(n_samples=1000, n_features=100, n_informative=2, scale=1.0,
+                        chunksize=100):
+    X = da.random.normal(0, 1, size=(n_samples, n_features),
+                         chunks=(chunksize, n_features))
+    informative_idx = np.random.choice(n_features, n_informative)
+    beta = (np.random.random(n_features) - 1) * scale
+    z0 = X[:, informative_idx].dot(beta[informative_idx])
+    y = da.random.random(z0.shape, chunks=(chunksize,)) < 1 / (1 + da.exp(-z0))
+    return X, y
+
+
+def make_regression(n_samples=1000, n_features=100, n_informative=2, scale=1.0,
+                    chunksize=100):
+    X = da.random.normal(0, 1, size=(n_samples, n_features),
+                         chunks=(chunksize, n_features))
+    informative_idx = np.random.choice(n_features, n_informative)
+    beta = (np.random.random(n_features) - 1) * scale
+    z0 = X[:, informative_idx].dot(beta[informative_idx])
+    y = da.random.random(z0.shape, chunks=(chunksize,))
+    return X, y

--- a/dask_glm/estimators.py
+++ b/dask_glm/estimators.py
@@ -1,0 +1,134 @@
+"""
+Models following scikit-learn's estimator API.
+"""
+from sklearn.base import BaseEstimator
+
+from . import algorithms
+from . import families
+from .utils import (
+    sigmoid, dot, add_intercept, mean_squared_error, accuracy_score
+)
+
+
+class _GLM(BaseEstimator):
+    @property
+    def family(self):
+        """
+        Family
+        """
+
+    def __init__(self, fit_intercept=True, solver='admm', regularizer='l2',
+                 max_iter=100, tol=1e-4, lamduh=1.0, rho=1,
+                 over_relax=1, abstol=1e-4, reltol=1e-2):
+        self.fit_intercept = True
+        self.solver = solver
+        self.regularizer = regularizer
+        self.max_iter = max_iter
+        self.tol = tol
+        self.lamduh = lamduh
+        self.rho = rho
+        self.over_relax = over_relax
+        self.abstol = abstol
+        self.reltol = reltol
+
+        self.coef_ = None
+        self.intercept_ = None
+        self._coef = None  # coef, maybe with intercept
+
+        fit_kwargs = {'max_iter', 'tol', 'family'}
+
+        if solver == 'admm':
+            fit_kwargs.discard('tol')
+            fit_kwargs.update({
+                'regularizer', 'lamduh', 'rho', 'over_relax', 'abstol',
+                'reltol'
+            })
+        elif solver == 'proximal_grad':
+            fit_kwargs.update({'regularizer', 'lamduh'})
+
+        self._fit_kwargs = {k: getattr(self, k) for k in fit_kwargs}
+
+    def fit(self, X, y=None):
+        X_ = self._maybe_add_intercept(X)
+        self._coef = algorithms._solvers[self.solver](X_, y, **self._fit_kwargs)
+
+        if self.fit_intercept:
+            self.coef_ = self._coef[:-1]
+            self.intercept_ = self._coef[-1]
+        else:
+            self.coef_ = self._coef
+        return self
+
+    def _maybe_add_intercept(self, X):
+        if self.fit_intercept:
+            return add_intercept(X)
+        else:
+            return X
+
+
+class LogisticRegression(_GLM):
+    """
+    Parameters
+    ----------
+    fit_intercept : bool, default True
+        Specifies if a constant (a.k.a. bias or intercept) should be
+        added to the decision function.
+    solver : {'admm', 'gradient_descent', 'newton', 'bfgs', 'proximal_grad'}
+        Solver to use. See :ref:`algorithms` for details
+    regularizer : {'l1', 'l2'}
+        Regularizer to use. See :ref:`regularizers` for details.
+        Only used with ``admm`` and ``proximal_grad`` solvers.
+    max_iter : int, default 100
+        Maximum number of iterations taken for the solvers to converge
+    tol : float, default 1e-4
+        Tolerance for stopping criteria. Ignored for ``admm`` solver
+    lambduh : float, default 1.0
+        Only used with ``admm`` and ``proximal_grad`` solvers
+    rho, over_relax, abstol, reltol : float
+        Only used with the ``admm`` solver. See :ref:`algorithms.admm`
+        for details
+
+    Attributes
+    ----------
+    coef_ : array, shape (n_classes, n_features)
+    intercept_ : float
+
+    Examples
+    --------
+    >>> from dask_glm.datasets import make_classification
+    >>> X, y = make_classification()
+    >>> lr = LogisticRegression()
+    >>> lr.fit(X, y)
+    >>> lr.predict(X)
+    >>> lr.predict_proba(X)
+    """
+
+    @property
+    def family(self):
+        return families.Logistic
+
+    def predict(self, X):
+        return self.predict_proba(X) > .5  # TODO: verify, multiclass broken
+
+    def predict_proba(self, X):
+        X_ = self._maybe_add_intercept(X)
+        return sigmoid(dot(X_, self._coef))
+
+    def score(self, X, y):
+        return accuracy_score(y, self.predict(X))
+
+
+class LinearRegression(_GLM):
+    """
+    Ordinary Lest Square regression
+    """
+    @property
+    def family(self):
+        return families.Normal
+
+    def predict(self, X):
+        X_ = self._maybe_add_intercept(X)
+        return dot(X_, self._coef)
+
+    def score(self, X, y):
+        return mean_squared_error(y, self.predict(X))

--- a/dask_glm/regularizers.py
+++ b/dask_glm/regularizers.py
@@ -79,3 +79,9 @@ class L1(object):
         def wrapped(beta, *args):
             return grad(beta, *args) + lam * L1.gradient(beta)
         return wrapped
+
+
+_regularizers = {
+    'l1': L1,
+    'l2': L2,
+}

--- a/dask_glm/tests/test_admm.py
+++ b/dask_glm/tests/test_admm.py
@@ -52,6 +52,6 @@ def test_admm_with_large_lamduh(N, p, nchunks):
     y = make_y(X, beta=np.array(beta), chunks=(N // nchunks,))
 
     X, y = persist(X, y)
-    z = admm(X, y, reg=L1, lamduh=1e4, rho=20, max_steps=500)
+    z = admm(X, y, regularizer=L1, lamduh=1e4, rho=20, max_iter=500)
 
     assert np.allclose(z, np.zeros(p), atol=1e-4)

--- a/dask_glm/tests/test_algos_families.py
+++ b/dask_glm/tests/test_algos_families.py
@@ -98,7 +98,7 @@ def test_basic_reg_descent(func, kwargs, N, nchunks, family, lam, reg):
 
     X, y = persist(X, y)
 
-    result = func(X, y, family=family, lamduh=lam, reg=reg, **kwargs)
+    result = func(X, y, family=family, lamduh=lam, regularizer=reg, **kwargs)
     test_vec = np.random.normal(size=2)
 
     f = reg.add_reg_f(family.pointwise_loss, lam)
@@ -110,10 +110,10 @@ def test_basic_reg_descent(func, kwargs, N, nchunks, family, lam, reg):
 
 
 @pytest.mark.parametrize('func,kwargs', [
-    (admm, {'max_steps': 2}),
-    (proximal_grad, {'max_steps': 2}),
-    (newton, {'max_steps': 2}),
-    (gradient_descent, {'max_steps': 2}),
+    (admm, {'max_iter': 2}),
+    (proximal_grad, {'max_iter': 2}),
+    (newton, {'max_iter': 2}),
+    (gradient_descent, {'max_iter': 2}),
 ])
 @pytest.mark.parametrize('get', [
     dask.async.get_sync,
@@ -137,10 +137,10 @@ except ImportError:
     pass
 else:
     @pytest.mark.parametrize('func,kwargs', [
-        (admm, {'max_steps': 2}),
-        (proximal_grad, {'max_steps': 2}),
-        (newton, {'max_steps': 2}),
-        (gradient_descent, {'max_steps': 2}),
+        (admm, {'max_iter': 2}),
+        (proximal_grad, {'max_iter': 2}),
+        (newton, {'max_iter': 2}),
+        (gradient_descent, {'max_iter': 2}),
     ])
     def test_determinism_distributed(func, kwargs, loop):
         with cluster() as (s, [a, b]):

--- a/dask_glm/tests/test_estimators.py
+++ b/dask_glm/tests/test_estimators.py
@@ -1,0 +1,91 @@
+import pytest
+
+from dask_glm.estimators import LogisticRegression, LinearRegression
+from dask_glm.datasets import make_classification, make_regression
+from dask_glm.algorithms import _solvers
+from dask_glm.regularizers import _regularizers
+
+
+@pytest.fixture(params=_solvers.keys())
+def solver(request):
+    """Parametrized fixture for all the solver names"""
+    return request.param
+
+
+@pytest.fixture(params=_regularizers.keys())
+def regularizer(request):
+    """Parametrized fixture for all the regularizer names"""
+    return request.param
+
+
+class DoNothingTransformer(object):
+    def fit(self, X, y=None):
+        return self
+
+    def transform(self, X, y=None):
+        return X
+
+    def fit_transform(self, X, y=None):
+        return X
+
+    def get_params(self, deep=True):
+        return {}
+
+
+X, y = make_classification()
+
+
+def test_lr_init(solver):
+    LogisticRegression(solver=solver)
+
+
+@pytest.mark.parametrize('fit_intercept', [True, False])
+def test_fit(fit_intercept):
+    X, y = make_classification(n_samples=100, n_features=5, chunksize=10)
+    lr = LogisticRegression(fit_intercept=fit_intercept)
+    lr.fit(X, y)
+    lr.predict(X)
+    lr.predict_proba(X)
+
+
+@pytest.mark.parametrize('fit_intercept', [True, False])
+def test_lm(fit_intercept):
+    X, y = make_regression(n_samples=100, n_features=5, chunksize=10)
+    lr = LinearRegression(fit_intercept=fit_intercept)
+    lr.fit(X, y)
+    lr.predict(X)
+    if fit_intercept:
+        assert lr.intercept_ is not None
+
+
+@pytest.mark.parametrize('fit_intercept', [True, False])
+def test_big(fit_intercept):
+    import dask
+    dask.set_options(get=dask.get)
+    X, y = make_classification()
+    lr = LogisticRegression(fit_intercept=fit_intercept)
+    lr.fit(X, y)
+    lr.predict(X)
+    lr.predict_proba(X)
+    if fit_intercept:
+        assert lr.intercept_ is not None
+
+
+def test_in_pipeline():
+    from sklearn.pipeline import make_pipeline
+    X, y = make_classification(n_samples=100, n_features=5, chunksize=10)
+    pipe = make_pipeline(DoNothingTransformer(), LogisticRegression())
+    pipe.fit(X, y)
+
+
+def test_gridsearch():
+    from sklearn.pipeline import make_pipeline
+    dcv = pytest.importorskip('dask_searchcv')
+
+    X, y = make_classification(n_samples=100, n_features=5, chunksize=10)
+    grid = {
+        'logisticregression__lamduh': [.001, .01, .1, .5]
+    }
+    pipe = make_pipeline(DoNothingTransformer(), LogisticRegression())
+    search = dcv.GridSearchCV(pipe, grid, cv=3)
+    search.fit(X, y)

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -1,0 +1,29 @@
+import numpy as np
+import dask.array as da
+
+from dask_glm import utils
+from dask.array.utils import assert_eq
+
+
+def test_add_intercept():
+    X = np.zeros((4, 4))
+    result = utils.add_intercept(X)
+    expected = np.array([
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+    ], dtype=X.dtype)
+    assert_eq(result, expected)
+
+
+def test_add_intercept_dask():
+    X = da.from_array(np.zeros((4, 4)), chunks=(2, 4))
+    result = utils.add_intercept(X)
+    expected = da.from_array(np.array([
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+    ], dtype=X.dtype), chunks=2)
+    assert_eq(result, expected)

--- a/notebooks/AccuracyBook.ipynb
+++ b/notebooks/AccuracyBook.ipynb
@@ -358,10 +358,10 @@
     "mod = LogisticRegression(penalty='l1', C = 1/lamduh, fit_intercept=False, tol=1e-8).fit(X.compute(), y.compute())\n",
     "sk_beta = mod.coef_\n",
     "\n",
-    "admm_beta = admm(X, y, lamduh=lamduh, max_steps=700, \n",
+    "admm_beta = admm(X, y, lamduh=lamduh, max_iter=700, \n",
     "                 abstol=1e-8, reltol=1e-2, pointwise_loss=pointwise_loss,\n",
     "                pointwise_gradient=pointwise_gradient)\n",
-    "prox_beta = proximal_grad(X, y, reg='l1', tol=1e-8, lamduh=lamduh)"
+    "prox_beta = proximal_grad(X, y, regularizer='l1', tol=1e-8, lamduh=lamduh)"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cloudpickle>=0.2.2
 dask[array]
 multipledispatch>=0.4.9
 scipy>=0.18.1
+scikit-learn>=0.18


### PR DESCRIPTION
Added a couple Estimators for an end-user API.

Basically

```python
from dask_glm.estimators import LogisticRegression
lr = LogisticRegresssion()
lr.fit(X, y)
```

To kick the [API discussion](https://github.com/dask/dask-glm/issues/11) even further down the road, right now it accepts either scikit-learn style `Estimator(...).fit(X, y)` or statsmodels-style `Estimator(X, y, ...).fit()`, but we should probably choose one or the other.

Here's an [example notebook](http://nbviewer.jupyter.org/gist/anonymous/ceed00b4c0518f88db71dabefc3afeff)

Some miscellaneous changes to help

- Added a `datasets.make_classification` helper
- Added string names for solvers
- Added an `add_intercept` helper ~(which I think might be broken right now...)~