### PR TITLE
Support sparse arrays

### DIFF
--- a/dask_glm/estimators.py
+++ b/dask_glm/estimators.py
@@ -20,7 +20,7 @@ class _GLM(BaseEstimator):
     def __init__(self, fit_intercept=True, solver='admm', regularizer='l2',
                  max_iter=100, tol=1e-4, lamduh=1.0, rho=1,
                  over_relax=1, abstol=1e-4, reltol=1e-2):
-        self.fit_intercept = True
+        self.fit_intercept = fit_intercept
         self.solver = solver
         self.regularizer = regularizer
         self.max_iter = max_iter

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 import dask.array as da
 
@@ -27,3 +28,13 @@ def test_add_intercept_dask():
         [0, 0, 0, 0, 1],
     ], dtype=X.dtype), chunks=2)
     assert_eq(result, expected)
+
+
+def test_sparse():
+    sparse = pytest.importorskip('sparse')
+    from sparse.utils import assert_eq
+    x = sparse.COO({(0, 0): 1, (1, 2): 2, (2, 1): 3})
+    y = x.todense()
+    assert utils.sum(x) == utils.sum(x.todense())
+    for func in [utils.sigmoid, utils.sum, utils.exp]:
+        assert_eq(func(x), func(y))

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
+import inspect
+import sys
+
 import dask.array as da
-from dask.utils import package_of
 import numpy as np
 from multipledispatch import dispatch
 
@@ -143,7 +145,24 @@ def accuracy_score(y_true, y_pred):
     return (y_true == y_pred).mean()
 
 
-import sparse
-@dispatch(sparse.COO)
-def exp(x):
-    return np.exp(x.todense())
+try:
+    import sparse
+except ImportError:
+    pass
+else:
+    @dispatch(sparse.COO)
+    def exp(x):
+        return np.exp(x.todense())
+
+
+def package_of(obj):
+    """ Return package containing object's definition
+
+    Or return None if not found
+    """
+    # http://stackoverflow.com/questions/43462701/get-package-of-python-object/43462865#43462865
+    mod = inspect.getmodule(obj)
+    if not mod:
+        return
+    base, _sep, _stem = mod.__name__.partition('.')
+    return sys.modules[base]

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -121,7 +121,7 @@ def add_intercept(X):
 def add_intercept(X):
     if np.isnan(np.sum(X.shape)):
         raise NotImplementedError("Can not add intercept to array with "
-                "unknown chunk shape")
+                                  "unknown chunk shape")
     j, k = X.chunks
     o = da.ones((X.shape[0], 1), chunks=(j, 1))
     # TODO: Needed this `.rechunk` for the solver to work


### PR DESCRIPTION
I've been playing recently with sparse arrays in https://github.com/mrocklin/sparse and in scipy.sparse.  I had to generalize the dispatched functions in utils.py a bit.  It would be nice to eventually depend on `__numpy_ufunc__` for most of this in the future.