### PR TITLE
Sparse+dense mixed arrays

### DIFF
--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -185,8 +185,6 @@ def admm(X, y, regularizer=L1, lamduh=0.1, rho=1, over_relax=1,
 
     if isinstance(X, da.Array):
         XD = X.to_delayed().tolist()
-        if len(XD[0]) == 1:
-            XD = [x[0] for x in XD]
     else:
         XD = [X]
 
@@ -237,10 +235,12 @@ def maybe_compute(x):
 
 
 def local_update(X, y, beta, z, u, rho, f, fprime, solver=fmin_l_bfgs_b):
-    if isinstance(X, list):
+    if len(X) > 1:
         X = [da.from_array(x, chunks=x.shape, name=False,
                            getitem=operator.getitem) for x in X]
         X = da.concatenate(X, axis=1)
+    else:
+        X = X[0]
 
     f2 = toolz.compose(maybe_compute, f)
     fprime2 = toolz.compose(maybe_compute, fprime)

--- a/dask_glm/tests/test_algos_families.py
+++ b/dask_glm/tests/test_algos_families.py
@@ -87,18 +87,20 @@ def test_basic_unreg_descent(func, kwargs, N, nchunks, family):
 ])
 @pytest.mark.parametrize('N', [1000])
 @pytest.mark.parametrize('nchunks', [1, 10])
+@pytest.mark.parametrize('mchunks', [1, 2])
 @pytest.mark.parametrize('family', [Logistic, Normal])
 @pytest.mark.parametrize('lam', [0.01, 1.2, 4.05])
 @pytest.mark.parametrize('reg', [L1, L2])
-def test_basic_reg_descent(func, kwargs, N, nchunks, family, lam, reg):
+def test_basic_reg_descent(func, kwargs, N, nchunks, mchunks, family, lam, reg):
     beta = np.random.normal(size=2)
     M = len(beta)
-    X = da.random.random((N, M), chunks=(N // nchunks, M))
+    X = da.random.random((N, M), chunks=(N // nchunks, M // mchunks))
     y = make_y(X, beta=np.array(beta), chunks=(N // nchunks,))
 
     X, y = persist(X, y)
 
-    result = func(X, y, family=family, lamduh=lam, regularizer=reg, **kwargs)
+    with dask.set_options(get=dask.get):  # for easy debugging when errors occur
+        result = func(X, y, family=family, lamduh=lam, regularizer=reg, **kwargs)
     test_vec = np.random.normal(size=2)
 
     f = reg.add_reg_f(family.pointwise_loss, lam)


### PR DESCRIPTION
Previously admm would rechunk the columns to be in a single chunk, and
then pass delayed numpy arrays to the local_update function.  If the
chunks along columns were of different types, like a numpy array and a
sparse array, then these would be inefficiently coerced to a single
type.

Now we pass a list of numpy arrays to the local_update function.  If
this list has more than one element then we construct a local dask.array
so that operations like dot do the right thing and call two different
local dot functions, one for each type.

This currently depends on https://github.com/dask/dask/pull/2272 though I may be able to avoid this dependency.