### PR TITLE
Logistic overflow and clean-up

### DIFF
--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -150,6 +150,7 @@ def newton(X, y, max_iter=50, tol=1e-8, family=Logistic, **kwargs):
     return beta
 
 
+@normalize()
 def admm(X, y, regularizer='l1', lamduh=0.1, rho=1, over_relax=1,
          max_iter=250, abstol=1e-4, reltol=1e-2, family=Logistic):
 
@@ -237,11 +238,6 @@ def local_update(X, y, beta, z, u, rho, f, fprime, solver=fmin_l_bfgs_b):
     return beta
 
 
-def shrinkage(x, kappa):
-    z = np.maximum(0, x - kappa) - np.maximum(0, -x - kappa)
-    return z
-
-
 @normalize()
 def bfgs(X, y, max_iter=500, tol=1e-14, family=Logistic, **kwargs):
     '''Simple implementation of BFGS.'''
@@ -316,6 +312,7 @@ def bfgs(X, y, max_iter=500, tol=1e-14, family=Logistic, **kwargs):
     return beta
 
 
+@normalize()
 def proximal_grad(X, y, regularizer='l1', lamduh=0.1, family=Logistic,
                   max_iter=100, tol=1e-8):
 

--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -113,7 +113,6 @@ def gradient_descent(X, y, max_iter=100, tol=1e-14, family=Logistic, **kwargs):
 
 @normalize()
 def newton(X, y, max_iter=50, tol=1e-8, family=Logistic, **kwargs):
-    '''Newtons Method for Logistic Regression.'''
 
     gradient, hessian = family.gradient, family.hessian
     n, p = X.shape

--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -56,7 +56,7 @@ def compute_stepsize_dask(beta, step, Xbeta, Xstep, y, curr_val,
     return stepSize, beta, Xbeta, func
 
 
-@normalize()
+@normalize
 def gradient_descent(X, y, max_iter=100, tol=1e-14, family=Logistic, **kwargs):
     '''Michael Grant's implementation of Gradient Descent.'''
 
@@ -111,7 +111,7 @@ def gradient_descent(X, y, max_iter=100, tol=1e-14, family=Logistic, **kwargs):
     return beta
 
 
-@normalize()
+@normalize
 def newton(X, y, max_iter=50, tol=1e-8, family=Logistic, **kwargs):
 
     gradient, hessian = family.gradient, family.hessian
@@ -149,7 +149,7 @@ def newton(X, y, max_iter=50, tol=1e-8, family=Logistic, **kwargs):
     return beta
 
 
-@normalize()
+@normalize
 def admm(X, y, regularizer='l1', lamduh=0.1, rho=1, over_relax=1,
          max_iter=250, abstol=1e-4, reltol=1e-2, family=Logistic):
 
@@ -237,7 +237,7 @@ def local_update(X, y, beta, z, u, rho, f, fprime, solver=fmin_l_bfgs_b):
     return beta
 
 
-@normalize()
+@normalize
 def lbfgs(X, y, regularizer=None, lamduh=1.0, max_iter=100, tol=1e-4,
           family=Logistic, verbose=False):
     """L-BFGS solver using scipy.optimize implementation"""
@@ -267,7 +267,7 @@ def lbfgs(X, y, regularizer=None, lamduh=1.0, max_iter=100, tol=1e-4,
     return beta
 
 
-@normalize()
+@normalize
 def proximal_grad(X, y, regularizer='l1', lamduh=0.1, family=Logistic,
                   max_iter=100, tol=1e-8):
 

--- a/dask_glm/families.py
+++ b/dask_glm/families.py
@@ -7,8 +7,8 @@ class Logistic(object):
 
     @staticmethod
     def loglike(Xbeta, y):
-        eXbeta = exp(Xbeta)
-        return (log1p(eXbeta)).sum() - dot(y, Xbeta)
+        enXbeta = exp(-Xbeta)
+        return (Xbeta + log1p(enXbeta)).sum() - dot(y, Xbeta)
 
     @staticmethod
     def pointwise_loss(beta, X, y):

--- a/dask_glm/tests/test_admm.py
+++ b/dask_glm/tests/test_admm.py
@@ -52,6 +52,6 @@ def test_admm_with_large_lamduh(N, p, nchunks):
     y = make_y(X, beta=np.array(beta), chunks=(N // nchunks,))
 
     X, y = persist(X, y)
-    z = admm(X, y, regularizer=L1, lamduh=1e4, rho=20, max_iter=500)
+    z = admm(X, y, regularizer=L1, lamduh=1e5, rho=20, max_iter=500)
 
     assert np.allclose(z, np.zeros(p), atol=1e-4)

--- a/dask_glm/tests/test_admm.py
+++ b/dask_glm/tests/test_admm.py
@@ -52,6 +52,6 @@ def test_admm_with_large_lamduh(N, p, nchunks):
     y = make_y(X, beta=np.array(beta), chunks=(N // nchunks,))
 
     X, y = persist(X, y)
-    z = admm(X, y, regularizer=L1(), lamduh=1e4, rho=20, max_iter=500)
+    z = admm(X, y, regularizer=L1(), lamduh=1e5, rho=20, max_iter=500)
 
     assert np.allclose(z, np.zeros(p), atol=1e-4)

--- a/dask_glm/tests/test_algos_families.py
+++ b/dask_glm/tests/test_algos_families.py
@@ -43,7 +43,7 @@ def make_intercept_data(N, p, seed=20009):
                             BFGS needs a re-work.'''),
                           newton, gradient_descent,
                           proximal_grad, admm])
-@pytest.mark.parametrize('reg', [L1, L2])
+@pytest.mark.parametrize('reg', [r() for r in Regularizer.__subclasses__()])
 def test_methods_return_numpy_arrays(opt, reg, seed=20009):
     X, y = make_intercept_data(100, 2, seed=seed)
     coefs = opt(X, y, **{'regularizer': reg})

--- a/dask_glm/tests/test_algos_families.py
+++ b/dask_glm/tests/test_algos_families.py
@@ -41,6 +41,18 @@ def make_intercept_data(N, p, seed=20009):
 @pytest.mark.parametrize('opt',
                          [pytest.mark.xfail(bfgs, reason='''
                             BFGS needs a re-work.'''),
+                          newton, gradient_descent,
+                          proximal_grad, admm])
+@pytest.mark.parametrize('reg', [L1, L2])
+def test_methods_return_numpy_arrays(opt, reg, seed=20009):
+    X, y = make_intercept_data(100, 2, seed=seed)
+    coefs = opt(X, y, **{'regularizer': reg})
+    assert type(coefs) == np.ndarray
+
+
+@pytest.mark.parametrize('opt',
+                         [pytest.mark.xfail(bfgs, reason='''
+                            BFGS needs a re-work.'''),
                           newton, gradient_descent])
 @pytest.mark.parametrize('N, p, seed',
                          [(100, 2, 20009),

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -7,7 +7,7 @@ from dask.array.utils import assert_eq
 
 
 def test_normalize_normalizes():
-    @utils.normalize(normalize=True)
+    @utils.normalize()
     def do_nothing(X, y):
         return np.array([0.0, 1.0, 2.0])
     X = da.from_array(np.array([[1, 0, 0], [1, 2, 2]]), chunks=(2, 3))
@@ -17,17 +17,17 @@ def test_normalize_normalizes():
 
 
 def test_normalize_doesnt_normalize():
-    @utils.normalize(normalize=False)
+    @utils.normalize()
     def do_nothing(X, y):
         return np.array([0.0, 1.0, 2.0])
     X = da.from_array(np.array([[1, 0, 0], [1, 2, 2]]), chunks=(2, 3))
     y = da.from_array(np.array([0, 1, 0]), chunks=(3, ))
-    res = do_nothing(X, y)
+    res = do_nothing(X, y, normalize=False)
     np.testing.assert_equal(res, np.array([0, 1, 2]))
 
 
 def test_normalize_normalizes_if_intercept_not_present():
-    @utils.normalize(normalize=True)
+    @utils.normalize()
     def do_nothing(X, y):
         return np.array([0.0, 1.0, 2.0])
     X = da.from_array(np.array([[1, 0, 0], [3, 9.0, 2]]), chunks=(2, 3))

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -36,6 +36,16 @@ def test_normalize_normalizes_if_intercept_not_present():
     np.testing.assert_equal(res, np.array([0, 1 / 4.5, 2]))
 
 
+def test_normalize_raises_if_multiple_constants():
+    @utils.normalize()
+    def do_nothing(X, y):
+        return np.array([0.0, 1.0, 2.0])
+    X = da.from_array(np.array([[1, 2, 3], [1, 2, 3]]), chunks=(2, 3))
+    y = da.from_array(np.array([0, 1, 0]), chunks=(3, ))
+    with pytest.raises(ValueError):
+        res = do_nothing(X, y)
+
+
 def test_add_intercept():
     X = np.zeros((4, 4))
     result = utils.add_intercept(X)

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -33,7 +33,7 @@ def test_normalize_normalizes_if_intercept_not_present():
     X = da.from_array(np.array([[1, 0, 0], [3, 9.0, 2]]), chunks=(2, 3))
     y = da.from_array(np.array([0, 1, 0]), chunks=(3, ))
     res = do_nothing(X, y)
-    np.testing.assert_equal(res, np.array([0, 1/4.5, 2]))
+    np.testing.assert_equal(res, np.array([0, 1 / 4.5, 2]))
 
 
 def test_add_intercept():

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -6,6 +6,36 @@ from dask_glm import utils
 from dask.array.utils import assert_eq
 
 
+def test_normalize_normalizes():
+    @utils.normalize(normalize=True)
+    def do_nothing(X, y):
+        return np.array([0.0, 1.0, 2.0])
+    X = da.from_array(np.array([[1, 0, 0], [1, 2, 2]]), chunks=(2, 3))
+    y = da.from_array(np.array([0, 1, 0]), chunks=(3, ))
+    res = do_nothing(X, y)
+    np.testing.assert_equal(res, np.array([-3.0, 1.0, 2.0]))
+
+
+def test_normalize_doesnt_normalize():
+    @utils.normalize(normalize=False)
+    def do_nothing(X, y):
+        return np.array([0.0, 1.0, 2.0])
+    X = da.from_array(np.array([[1, 0, 0], [1, 2, 2]]), chunks=(2, 3))
+    y = da.from_array(np.array([0, 1, 0]), chunks=(3, ))
+    res = do_nothing(X, y)
+    np.testing.assert_equal(res, np.array([0, 1, 2]))
+
+
+def test_normalize_doesnt_normalize_if_intercept_not_present():
+    @utils.normalize(normalize=True)
+    def do_nothing(X, y):
+        return np.array([0.0, 1.0, 2.0])
+    X = da.from_array(np.array([[1, 0, 0], [3, 9.0, 2]]), chunks=(2, 3))
+    y = da.from_array(np.array([0, 1, 0]), chunks=(3, ))
+    res = do_nothing(X, y)
+    np.testing.assert_equal(res, np.array([0, 1, 2]))
+
+
 def test_add_intercept():
     X = np.zeros((4, 4))
     result = utils.add_intercept(X)

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -7,7 +7,7 @@ from dask.array.utils import assert_eq
 
 
 def test_normalize_normalizes():
-    @utils.normalize()
+    @utils.normalize
     def do_nothing(X, y):
         return np.array([0.0, 1.0, 2.0])
     X = da.from_array(np.array([[1, 0, 0], [1, 2, 2]]), chunks=(2, 3))
@@ -17,7 +17,7 @@ def test_normalize_normalizes():
 
 
 def test_normalize_doesnt_normalize():
-    @utils.normalize()
+    @utils.normalize
     def do_nothing(X, y):
         return np.array([0.0, 1.0, 2.0])
     X = da.from_array(np.array([[1, 0, 0], [1, 2, 2]]), chunks=(2, 3))
@@ -27,7 +27,7 @@ def test_normalize_doesnt_normalize():
 
 
 def test_normalize_normalizes_if_intercept_not_present():
-    @utils.normalize()
+    @utils.normalize
     def do_nothing(X, y):
         return np.array([0.0, 1.0, 2.0])
     X = da.from_array(np.array([[1, 0, 0], [3, 9.0, 2]]), chunks=(2, 3))
@@ -37,7 +37,7 @@ def test_normalize_normalizes_if_intercept_not_present():
 
 
 def test_normalize_raises_if_multiple_constants():
-    @utils.normalize()
+    @utils.normalize
     def do_nothing(X, y):
         return np.array([0.0, 1.0, 2.0])
     X = da.from_array(np.array([[1, 2, 3], [1, 2, 3]]), chunks=(2, 3))

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -26,14 +26,14 @@ def test_normalize_doesnt_normalize():
     np.testing.assert_equal(res, np.array([0, 1, 2]))
 
 
-def test_normalize_doesnt_normalize_if_intercept_not_present():
+def test_normalize_normalizes_if_intercept_not_present():
     @utils.normalize(normalize=True)
     def do_nothing(X, y):
         return np.array([0.0, 1.0, 2.0])
     X = da.from_array(np.array([[1, 0, 0], [3, 9.0, 2]]), chunks=(2, 3))
     y = da.from_array(np.array([0, 1, 0]), chunks=(3, ))
     res = do_nothing(X, y)
-    np.testing.assert_equal(res, np.array([0, 1, 2]))
+    np.testing.assert_equal(res, np.array([0, 1/4.5, 2]))
 
 
 def test_add_intercept():

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -15,10 +15,11 @@ def normalize(normalize=True):
         def normalize_inputs(X, y, *args, **kwargs):
             if normalize:
                 mean, std = da.compute(X.mean(axis=0), X.std(axis=0))
+                mean, std = mean.copy(), std.copy()
                 intercept_idx = np.where(std == 0)
                 mean[intercept_idx] = 0
                 std[intercept_idx] = 1
-                mean = mean if intercept_idx[0] else np.zeros(mean.shape)
+                mean = mean if len(intercept_idx[0]) else np.zeros(mean.shape)
                 Xn = (X - mean) / std
                 out = algo(Xn, y, *args, **kwargs)
                 i_adj = np.sum(out * mean / std)

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -9,10 +9,11 @@ from functools import wraps
 from multipledispatch import dispatch
 
 
-def normalize(normalize=True):
+def normalize():
     def decorator(algo):
         @wraps(algo)
         def normalize_inputs(X, y, *args, **kwargs):
+            normalize = kwargs.pop('normalize', True)
             if normalize:
                 mean, std = da.compute(X.mean(axis=0), X.std(axis=0))
                 mean, std = mean.copy(), std.copy()

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -16,7 +16,7 @@ def normalize():
             normalize = kwargs.pop('normalize', True)
             if normalize:
                 mean, std = da.compute(X.mean(axis=0), X.std(axis=0))
-                mean, std = mean.copy(), std.copy() # in case they are read-only
+                mean, std = mean.copy(), std.copy()  # in case they are read-only
                 intercept_idx = np.where(std == 0)
                 if len(intercept_idx[0]) > 1:
                     raise ValueError('Multiple constant columns detected!')

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -16,7 +16,7 @@ def normalize():
             normalize = kwargs.pop('normalize', True)
             if normalize:
                 mean, std = da.compute(X.mean(axis=0), X.std(axis=0))
-                mean, std = mean.copy(), std.copy()
+                mean, std = mean.copy(), std.copy() # in case they are read-only
                 intercept_idx = np.where(std == 0)
                 if len(intercept_idx[0]) > 1:
                     raise ValueError('Multiple constant columns detected!')

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -18,6 +18,8 @@ def normalize():
                 mean, std = da.compute(X.mean(axis=0), X.std(axis=0))
                 mean, std = mean.copy(), std.copy()
                 intercept_idx = np.where(std == 0)
+                if len(intercept_idx[0]) > 1:
+                    raise ValueError('Multiple constant columns detected!')
                 mean[intercept_idx] = 0
                 std[intercept_idx] = 1
                 mean = mean if len(intercept_idx[0]) else np.zeros(mean.shape)

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -9,29 +9,27 @@ from functools import wraps
 from multipledispatch import dispatch
 
 
-def normalize():
-    def decorator(algo):
-        @wraps(algo)
-        def normalize_inputs(X, y, *args, **kwargs):
-            normalize = kwargs.pop('normalize', True)
-            if normalize:
-                mean, std = da.compute(X.mean(axis=0), X.std(axis=0))
-                mean, std = mean.copy(), std.copy()  # in case they are read-only
-                intercept_idx = np.where(std == 0)
-                if len(intercept_idx[0]) > 1:
-                    raise ValueError('Multiple constant columns detected!')
-                mean[intercept_idx] = 0
-                std[intercept_idx] = 1
-                mean = mean if len(intercept_idx[0]) else np.zeros(mean.shape)
-                Xn = (X - mean) / std
-                out = algo(Xn, y, *args, **kwargs)
-                i_adj = np.sum(out * mean / std)
-                out[intercept_idx] -= i_adj
-                return out / std
-            else:
-                return algo(X, y, *args, **kwargs)
-        return normalize_inputs
-    return decorator
+def normalize(algo):
+    @wraps(algo)
+    def normalize_inputs(X, y, *args, **kwargs):
+        normalize = kwargs.pop('normalize', True)
+        if normalize:
+            mean, std = da.compute(X.mean(axis=0), X.std(axis=0))
+            mean, std = mean.copy(), std.copy()  # in case they are read-only
+            intercept_idx = np.where(std == 0)
+            if len(intercept_idx[0]) > 1:
+                raise ValueError('Multiple constant columns detected!')
+            mean[intercept_idx] = 0
+            std[intercept_idx] = 1
+            mean = mean if len(intercept_idx[0]) else np.zeros(mean.shape)
+            Xn = (X - mean) / std
+            out = algo(Xn, y, *args, **kwargs)
+            i_adj = np.sum(out * mean / std)
+            out[intercept_idx] -= i_adj
+            return out / std
+        else:
+            return algo(X, y, *args, **kwargs)
+    return normalize_inputs
 
 
 def sigmoid(x):

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -18,11 +18,12 @@ def normalize(normalize=True):
                 intercept_idx = np.where(std == 0)
                 mean[intercept_idx] = 0
                 std[intercept_idx] = 1
-                Xn = (X - mean) / std if intercept_idx[0] else X
+                mean = mean if intercept_idx[0] else np.zeros(mean.shape)
+                Xn = (X - mean) / std
                 out = algo(Xn, y, *args, **kwargs)
                 i_adj = np.sum(out * mean / std)
                 out[intercept_idx] -= i_adj
-                return out / std if intercept_idx[0] else out
+                return out / std
             else:
                 return algo(X, y, *args, **kwargs)
         return normalize_inputs


### PR DESCRIPTION
An initial attempt to address #41:

- [x] reduce overflows in calls to `Logistic.loglike`

- [x] remove all `print` statements

- [x] add test for `numpy` output

- [x] fix failing distributed determinism test

- [x] determine how to handle scaling in the absence of an intercept

This *doesn't* close #41 yet, because I don't currently scale inputs when an intercept is not present to absorb the means.

I'm not sure why I made `normalize` a decorator, it seemed like the right thing to do at the time; alternatively, we could just make it a keyword argument to both the estimators and the algorithms.  Open to input here.