### PR TITLE
ENH: Allow add_intercept for unknown dims

### DIFF
--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -30,6 +30,18 @@ def test_add_intercept_dask():
     assert_eq(result, expected)
 
 
+def test_add_intercept_unknown():
+    dd = pytest.importorskip('dask.dataframe')
+    X = dd.from_array(da.from_array(np.zeros((4, 4)), chunks=(2, 4))).values
+    result = utils.add_intercept(X)
+    expected = da.from_array(np.array([
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+    ], dtype=X.dtype), chunks=2)
+    assert_eq(result, expected)
+
 def test_sparse():
     sparse = pytest.importorskip('sparse')
     from sparse.utils import assert_eq

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -117,16 +117,16 @@ def add_intercept(X):
     return np.concatenate([X, np.ones((X.shape[0], 1))], axis=1)
 
 
+def _add_intercept_block(x):
+    o = np.ones((len(x), 1), dtype=x.dtype)
+    return np.concatenate([x, o], axis=1)
+
+
 @dispatch(da.Array)
 def add_intercept(X):
-    if np.isnan(np.sum(X.shape)):
-        raise NotImplementedError("Can not add intercept to array with "
-                                  "unknown chunk shape")
     j, k = X.chunks
-    o = da.ones((X.shape[0], 1), chunks=(j, 1))
-    # TODO: Needed this `.rechunk` for the solver to work
-    # Is this OK / correct?
-    X_i = da.concatenate([X, o], axis=1).rechunk((j, (k[0] + 1,)))
+    k2 = (__builtins__['sum'](k) + 1,)
+    X_i = X.map_blocks(_add_intercept_block, dtype=X.dtype, chunks=(j, k2))
     return X_i
 
 


### PR DESCRIPTION
Ran into this for https://gist.github.com/TomAugspurger/30ec08cc29810b57b4cb4458828e46c9

Fixes https://github.com/dask/dask-glm/issues/13 (I think)

One side issue: is it safe to assume that `X` will always be chunked *only* along the rows? Perhaps we should add a utility method that rechunks so this is true (will have to rely on https://github.com/dask/dask/pull/2251)