### PR TITLE
L-BFGS solver based on scipy.optimize with L2 regularization

### DIFF
--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -243,14 +243,15 @@ def shrinkage(x, kappa):
     return z
 
 
-def lbfgs(X, y, max_iter=100, tol=1e-4, alpha=1.0, family=Logistic, verbose=False):
+def lbfgs(X, y, regularizer='l1', alpha=1.0, max_iter=100, tol=1e-4,
+          family=Logistic, verbose=False):
     """L-BFGS solver using scipy.optimize implementation
     
     Currently supports L2 regularization only"""
 
     pointwise_loss = family.pointwise_loss
     pointwise_gradient = family.pointwise_gradient
-    regularizer = Regularizer.get('l2')
+    regularizer = Regularizer.get(regularizer)
 
     n, p = X.shape
     beta0 = np.zeros(p)

--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -243,11 +243,9 @@ def shrinkage(x, kappa):
     return z
 
 
-def lbfgs(X, y, regularizer='l1', alpha=1.0, max_iter=100, tol=1e-4,
+def lbfgs(X, y, regularizer='l2', alpha=1.0, max_iter=100, tol=1e-4,
           family=Logistic, verbose=False):
-    """L-BFGS solver using scipy.optimize implementation
-
-    Currently supports L2 regularization only"""
+    """L-BFGS solver using scipy.optimize implementation"""
 
     pointwise_loss = family.pointwise_loss
     pointwise_gradient = family.pointwise_gradient

--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -22,7 +22,7 @@ import dask.array as da
 from scipy.optimize import fmin_l_bfgs_b
 
 
-from dask_glm.utils import dot, exp, log1p
+from dask_glm.utils import dot
 from dask_glm.families import Logistic
 from dask_glm.regularizers import Regularizer
 
@@ -243,7 +243,7 @@ def shrinkage(x, kappa):
     return z
 
 
-def lbfgs(X, y, regularizer=None, alpha=1.0, max_iter=100, tol=1e-4,
+def lbfgs(X, y, regularizer=None, lamduh=1.0, max_iter=100, tol=1e-4,
           family=Logistic, verbose=False):
     """L-BFGS solver using scipy.optimize implementation"""
 
@@ -251,8 +251,8 @@ def lbfgs(X, y, regularizer=None, alpha=1.0, max_iter=100, tol=1e-4,
     pointwise_gradient = family.pointwise_gradient
     if regularizer:
         regularizer = Regularizer.get(regularizer)
-        pointwise_loss = regularizer.add_reg_f(pointwise_loss, alpha)
-        pointwise_gradient = regularizer.add_reg_grad(pointwise_gradient, alpha)
+        pointwise_loss = regularizer.add_reg_f(pointwise_loss, lamduh)
+        pointwise_gradient = regularizer.add_reg_grad(pointwise_gradient, lamduh)
 
     n, p = X.shape
     beta0 = np.zeros(p)

--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -246,7 +246,7 @@ def shrinkage(x, kappa):
 def lbfgs(X, y, regularizer='l1', alpha=1.0, max_iter=100, tol=1e-4,
           family=Logistic, verbose=False):
     """L-BFGS solver using scipy.optimize implementation
-    
+
     Currently supports L2 regularization only"""
 
     pointwise_loss = family.pointwise_loss

--- a/dask_glm/estimators.py
+++ b/dask_glm/estimators.py
@@ -43,7 +43,7 @@ class _GLM(BaseEstimator):
                 'regularizer', 'lamduh', 'rho', 'over_relax', 'abstol',
                 'reltol'
             })
-        elif solver == 'proximal_grad':
+        elif solver == 'proximal_grad' or solver == 'lbfgs':
             fit_kwargs.update({'regularizer', 'lamduh'})
 
         self._fit_kwargs = {k: getattr(self, k) for k in fit_kwargs}
@@ -73,17 +73,17 @@ class LogisticRegression(_GLM):
     fit_intercept : bool, default True
         Specifies if a constant (a.k.a. bias or intercept) should be
         added to the decision function.
-    solver : {'admm', 'gradient_descent', 'newton', 'bfgs', 'proximal_grad'}
+    solver : {'admm', 'gradient_descent', 'newton', 'lbfgs', 'proximal_grad'}
         Solver to use. See :ref:`algorithms` for details
     regularizer : {'l1', 'l2'}
         Regularizer to use. See :ref:`regularizers` for details.
-        Only used with ``admm`` and ``proximal_grad`` solvers.
+        Only used with ``admm``, ``lbfgs`` and ``proximal_grad`` solvers.
     max_iter : int, default 100
         Maximum number of iterations taken for the solvers to converge
     tol : float, default 1e-4
         Tolerance for stopping criteria. Ignored for ``admm`` solver
     lambduh : float, default 1.0
-        Only used with ``admm`` and ``proximal_grad`` solvers
+        Only used with ``admm``, ``lbfgs`` and ``proximal_grad`` solvers.
     rho, over_relax, abstol, reltol : float
         Only used with the ``admm`` solver. See :ref:`algorithms.admm`
         for details
@@ -142,17 +142,17 @@ class PoissonRegression(_GLM):
     fit_intercept : bool, default True
         Specifies if a constant (a.k.a. bias or intercept) should be
         added to the decision function.
-    solver : {'admm', 'gradient_descent', 'newton', 'bfgs', 'proximal_grad'}
+    solver : {'admm', 'gradient_descent', 'newton', 'lbfgs', 'proximal_grad'}
         Solver to use. See :ref:`algorithms` for details
     regularizer : {'l1', 'l2'}
         Regularizer to use. See :ref:`regularizers` for details.
-        Only used with ``admm`` and ``proximal_grad`` solvers.
+        Only used with ``admm``, ``lbfgs`` and ``proximal_grad`` solvers.
     max_iter : int, default 100
         Maximum number of iterations taken for the solvers to converge
     tol : float, default 1e-4
         Tolerance for stopping criteria. Ignored for ``admm`` solver
     lambduh : float, default 1.0
-        Only used with ``admm`` and ``proximal_grad`` solvers
+        Only used with ``admm``, ``lbfgs`` and ``proximal_grad`` solvers.
     rho, over_relax, abstol, reltol : float
         Only used with the ``admm`` solver. See :ref:`algorithms.admm`
         for details

--- a/dask_glm/tests/test_algos_families.py
+++ b/dask_glm/tests/test_algos_families.py
@@ -6,7 +6,7 @@ from dask import persist
 import numpy as np
 import dask.array as da
 
-from dask_glm.algorithms import (newton, bfgs, proximal_grad,
+from dask_glm.algorithms import (newton, lbfgs, proximal_grad,
                                  gradient_descent, admm)
 from dask_glm.families import Logistic, Normal, Poisson
 from dask_glm.regularizers import Regularizer
@@ -39,9 +39,9 @@ def make_intercept_data(N, p, seed=20009):
 
 
 @pytest.mark.parametrize('opt',
-                         [pytest.mark.xfail(bfgs, reason='''
-                            BFGS needs a re-work.'''),
-                          newton, gradient_descent])
+                         [lbfgs,
+                          newton,
+                          gradient_descent])
 @pytest.mark.parametrize('N, p, seed',
                          [(100, 2, 20009),
                           (250, 12, 90210),
@@ -58,7 +58,7 @@ def test_methods(N, p, seed, opt):
 
 @pytest.mark.parametrize('func,kwargs', [
     (newton, {'tol': 1e-5}),
-    pytest.mark.xfail((bfgs, {'tol': 1e-8}), reason='BFGS needs a re-work.'),
+    (lbfgs, {'tol': 1e-8}),
     (gradient_descent, {'tol': 1e-7}),
 ])
 @pytest.mark.parametrize('N', [1000])


### PR DESCRIPTION
Refer to #30 for the discussion and prototype from which this was developed.

Still a little bit WIP, though it supports `L2` regularizer and:
* is equivalent to sklearn's `LogisticRegression` with `solver=lbfgs` and `fit_intercept=False`
* doesn't give precisely the same solution as sklearn's `Ridge` for squared loss (as the solvers are different), but achieves essentially the same RMSE metric on some simple test data (`fit_intercept=False`)

Todos:
- [ ] test cases
- [ ] maybe some performance testing (refer e.g. https://gist.github.com/mrocklin/4e486064882cce630ffb4ee4e39bc333)
- [ ] support `L1` regularizer (via adapting https://gist.github.com/vene/fab06038a00309569cdd). Could this potentially also support `ElasticNet` regularizer?

**Note** not sure if the estimator versions will give the same results as sklearn because intercept handling may be different. Still need to investigate.