### PR TITLE
Update to use dask.config.set and schduler keyword

### DIFF
--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -3,7 +3,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-from dask import delayed, persist, compute, set_options
+import dask
+from dask import delayed, persist, compute
 import functools
 import numpy as np
 import dask.array as da
@@ -338,7 +339,7 @@ def lbfgs(X, y, regularizer=None, lamduh=1.0, max_iter=100, tol=1e-4,
         loss, gradient = compute(loss_fn, gradient_fn)
         return loss, gradient.copy()
 
-    with set_options(fuse_ave_width=0):  # optimizations slows this down
+    with dask.config.set(fuse_ave_width=0):  # optimizations slows this down
         beta, loss, info = fmin_l_bfgs_b(
             compute_loss_grad, beta0, fprime=None,
             args=(X, y),

--- a/dask_glm/tests/test_algos_families.py
+++ b/dask_glm/tests/test_algos_families.py
@@ -115,15 +115,15 @@ def test_basic_reg_descent(func, kwargs, N, nchunks, family, lam, reg):
     (newton, {'max_iter': 2}),
     (gradient_descent, {'max_iter': 2}),
 ])
-@pytest.mark.parametrize('get', [
-    dask.local.get_sync,
-    dask.threaded.get,
-    dask.multiprocessing.get
+@pytest.mark.parametrize('scheduler', [
+    'synchronous',
+    'threading',
+    'multiprocessing'
 ])
-def test_determinism(func, kwargs, get):
+def test_determinism(func, kwargs, scheduler):
     X, y = make_intercept_data(1000, 10)
 
-    with dask.set_options(get=get):
+    with dask.config.set(scheduler=scheduler):
         a = func(X, y, **kwargs)
         b = func(X, y, **kwargs)
 

--- a/dask_glm/tests/test_estimators.py
+++ b/dask_glm/tests/test_estimators.py
@@ -64,7 +64,7 @@ def test_lm(fit_intercept):
 @pytest.mark.parametrize('fit_intercept', [True, False])
 def test_big(fit_intercept):
     import dask
-    dask.set_options(get=dask.get)
+    dask.config.set(scheduler='synchronous')
     X, y = make_classification()
     lr = LogisticRegression(fit_intercept=fit_intercept)
     lr.fit(X, y)
@@ -77,7 +77,7 @@ def test_big(fit_intercept):
 @pytest.mark.parametrize('fit_intercept', [True, False])
 def test_poisson_fit(fit_intercept):
     import dask
-    dask.set_options(get=dask.get)
+    dask.config.set(scheduler='synchronous')
     X, y = make_poisson()
     pr = PoissonRegression(fit_intercept=fit_intercept)
     pr.fit(X, y)

--- a/dask_glm/tests/test_estimators.py
+++ b/dask_glm/tests/test_estimators.py
@@ -1,4 +1,5 @@
 import pytest
+import dask
 
 from dask_glm.estimators import LogisticRegression, LinearRegression, PoissonRegression
 from dask_glm.datasets import make_classification, make_regression, make_poisson
@@ -63,7 +64,6 @@ def test_lm(fit_intercept):
 
 @pytest.mark.parametrize('fit_intercept', [True, False])
 def test_big(fit_intercept):
-    import dask
     with dask.config.set(scheduler='synchronous'):
         X, y = make_classification()
         lr = LogisticRegression(fit_intercept=fit_intercept)
@@ -76,7 +76,6 @@ def test_big(fit_intercept):
 
 @pytest.mark.parametrize('fit_intercept', [True, False])
 def test_poisson_fit(fit_intercept):
-    import dask
     with dask.config.set(scheduler='synchronous'):
         X, y = make_poisson()
         pr = PoissonRegression(fit_intercept=fit_intercept)

--- a/dask_glm/tests/test_estimators.py
+++ b/dask_glm/tests/test_estimators.py
@@ -64,12 +64,12 @@ def test_lm(fit_intercept):
 @pytest.mark.parametrize('fit_intercept', [True, False])
 def test_big(fit_intercept):
     import dask
-    dask.config.set(scheduler='synchronous')
-    X, y = make_classification()
-    lr = LogisticRegression(fit_intercept=fit_intercept)
-    lr.fit(X, y)
-    lr.predict(X)
-    lr.predict_proba(X)
+    with dask.config.set(scheduler='synchronous'):
+        X, y = make_classification()
+        lr = LogisticRegression(fit_intercept=fit_intercept)
+        lr.fit(X, y)
+        lr.predict(X)
+        lr.predict_proba(X)
     if fit_intercept:
         assert lr.intercept_ is not None
 
@@ -77,12 +77,12 @@ def test_big(fit_intercept):
 @pytest.mark.parametrize('fit_intercept', [True, False])
 def test_poisson_fit(fit_intercept):
     import dask
-    dask.config.set(scheduler='synchronous')
-    X, y = make_poisson()
-    pr = PoissonRegression(fit_intercept=fit_intercept)
-    pr.fit(X, y)
-    pr.predict(X)
-    pr.get_deviance(X, y)
+    with dask.config.set(scheduler='synchronous'):
+        X, y = make_poisson()
+        pr = PoissonRegression(fit_intercept=fit_intercept)
+        pr.fit(X, y)
+        pr.predict(X)
+        pr.get_deviance(X, y)
     if fit_intercept:
         assert pr.intercept_ is not None
 


### PR DESCRIPTION
This PR replaces instances of `dask.set_options` with `dask.config.set` and replaces usage of the `get` keyword with the `sceduler` keyword. 

Previously these would raise warnings, but https://github.com/dask/dask/pull/4077 elevated these warning to errors. 