### PR TITLE
Scatter lbfgs weights to workers. Inject dask client to lbfgs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 env:
   matrix:
-    - PYTHON=2.7 IPYTHON_KERNEL=python2
     - PYTHON=3.5 IPYTHON_KERNEL=python3
 
 install:

--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -341,8 +341,8 @@ def lbfgs(X, y, regularizer=None, lamduh=1.0, max_iter=100, tol=1e-4,
     def compute_loss_grad(beta, X, y):
         scatter_beta = scatter_array(
             beta, dask_distributed_client) if dask_distributed_client else beta
-        loss_fn = pointwise_loss(beta, X, y)
-        gradient_fn = pointwise_gradient(beta, X, y)
+        loss_fn = pointwise_loss(scatter_beta, X, y)
+        gradient_fn = pointwise_gradient(scatter_beta, X, y)
         loss, gradient = compute(loss_fn, gradient_fn)
         return loss, gradient.copy()
 

--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -11,7 +11,7 @@ import dask.array as da
 from scipy.optimize import fmin_l_bfgs_b
 
 
-from dask_glm.utils import dot, normalize, scatter_array
+from dask_glm.utils import dot, normalize, scatter_array, get_distributed_client
 from dask_glm.families import Logistic
 from dask_glm.regularizers import Regularizer
 
@@ -304,8 +304,7 @@ def local_update(X, y, beta, z, u, rho, f, fprime, solver=fmin_l_bfgs_b):
 
 @normalize
 def lbfgs(X, y, regularizer=None, lamduh=1.0, max_iter=100, tol=1e-4,
-          family=Logistic, verbose=False, dask_distributed_client=None,
-          **kwargs):
+          family=Logistic, verbose=False, **kwargs):
     """L-BFGS solver using scipy.optimize implementation
 
     Parameters
@@ -323,13 +322,12 @@ def lbfgs(X, y, regularizer=None, lamduh=1.0, max_iter=100, tol=1e-4,
     family : Family
     verbose : bool, default False
         whether to print diagnostic information during convergence
-    dask_distributed_client: dask client, default None
-        If given, use it to broadcast model weights to workers.
 
     Returns
     -------
     beta : array-like, shape (n_features,)
     """
+    dask_distributed_client = get_distributed_client()
     pointwise_loss = family.pointwise_loss
     pointwise_gradient = family.pointwise_gradient
     if regularizer is not None:

--- a/dask_glm/tests/test_algos_families.py
+++ b/dask_glm/tests/test_algos_families.py
@@ -151,3 +151,14 @@ else:
                 b = func(X, y, **kwargs)
 
                 assert (a == b).all()
+
+    def broadcast_lbfgs_weight():
+        with cluster() as (s, [a, b]):
+            with Client(s['address'], loop=loop) as c:
+                X, y = make_intercept_data(1000, 10)
+                coefs = lbfgs(X, y, dask_distributed_client=c)
+                p = sigmoid(X.dot(coefs).compute())
+
+                y_sum = y.compute().sum()
+                p_sum = p.sum()
+                assert np.isclose(y_sum, p_sum, atol=1e-1)

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import inspect
 import sys
 
-import dask.distributed as dd
+from dask.distributed import get_client
 import dask.array as da
 import numpy as np
 from functools import wraps
@@ -207,6 +207,6 @@ def scatter_array(arr, dask_client):
 
 def get_distributed_client():
     try:
-        return dd.get_client()
+        return get_client()
     except ValueError:
         return None

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -194,3 +194,11 @@ def package_of(obj):
         return
     base, _sep, _stem = mod.__name__.partition('.')
     return sys.modules[base]
+
+
+def scatter_array(arr, dask_client):
+    """Scatter a large numpy array into workers
+    Return the equivalent dask array
+    """
+    future_arr = dask_client.scatter(arr)
+    return da.from_delayed(future_arr, shape=arr.shape, dtype=arr.dtype)

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import inspect
 import sys
 
+import dask.distributed as dd
 import dask.array as da
 import numpy as np
 from functools import wraps
@@ -202,3 +203,10 @@ def scatter_array(arr, dask_client):
     """
     future_arr = dask_client.scatter(arr)
     return da.from_delayed(future_arr, shape=arr.shape, dtype=arr.dtype)
+
+
+def get_distributed_client():
+    try:
+        return dd.get_client()
+    except ValueError:
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dask[array]
 multipledispatch>=0.4.9
 scipy>=0.18.1
 scikit-learn>=0.18
+distributed


### PR DESCRIPTION
In case of optimization in large space (say a hashing space of 2**25 size).
The results can be big (> 55MB) and must be broadcasted to workers.

Note: If the beta array is not scattered, it will be serialized with dask task. It will make the dask graph to big to be handle by the scheduler.

This commit introduce a new option to inject dask distributed client to lbfgs. If present, we use it to scatter the beta vector. In dask-ml, this client can be injected using the solver_kwargs argument.