### PR TITLE
Add support of sparse matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 env:
   matrix:
-    - PYTHON=3.5 IPYTHON_KERNEL=python3
+    - PYTHON=3.7 IPYTHON_KERNEL=python3
 
 install:
   # Install conda
@@ -14,7 +14,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n test-environment -c conda-forge python=$PYTHON numpy>=1.17.0 flake8 pytest scipy multipledispatch cloudpickle numba dask mock scikit-learn jupyter sparse>=0.7.0
+  - conda create -n test-environment -c conda-forge python=$PYTHON numpy flake8 pytest scipy multipledispatch cloudpickle numba dask mock scikit-learn jupyter sparse
   - source activate test-environment
   - pip install git+https://github.com/dask/dask
   - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - conda create -n test-environment -c conda-forge python=$PYTHON numpy flake8 pytest scipy multipledispatch cloudpickle numba dask mock scikit-learn jupyter sparse>=0.7.0
   - source activate test-environment
   - pip install git+https://github.com/dask/dask
+  - conda list
 
   # Install dask-glm
   - pip install --no-deps -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n test-environment -c conda-forge python=$PYTHON numpy flake8 pytest scipy multipledispatch cloudpickle numba dask mock scikit-learn jupyter
+  - conda create -n test-environment -c conda-forge python=$PYTHON numpy flake8 pytest scipy multipledispatch cloudpickle numba dask mock scikit-learn jupyter sparse
   - source activate test-environment
   - pip install git+https://github.com/dask/dask
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n test-environment -c conda-forge python=$PYTHON numpy flake8 pytest scipy multipledispatch cloudpickle numba dask mock scikit-learn jupyter sparse
+  - conda create -n test-environment -c conda-forge python=$PYTHON numpy flake8 pytest scipy multipledispatch cloudpickle numba dask mock scikit-learn jupyter sparse>=0.7.0
   - source activate test-environment
   - pip install git+https://github.com/dask/dask
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n test-environment -c conda-forge python=$PYTHON numpy flake8 pytest scipy multipledispatch cloudpickle numba dask mock scikit-learn jupyter sparse>=0.7.0
+  - conda create -n test-environment -c conda-forge python=$PYTHON numpy>=1.17.0 flake8 pytest scipy multipledispatch cloudpickle numba dask mock scikit-learn jupyter sparse>=0.7.0
   - source activate test-environment
   - pip install git+https://github.com/dask/dask
   - conda list

--- a/dask_glm/datasets.py
+++ b/dask_glm/datasets.py
@@ -1,10 +1,11 @@
 import numpy as np
+import sparse
 import dask.array as da
 from dask_glm.utils import exp
 
 
 def make_classification(n_samples=1000, n_features=100, n_informative=2, scale=1.0,
-                        chunksize=100):
+                        chunksize=100, is_sparse=False):
     """
     Generate a dummy dataset for classification tasks.
 
@@ -20,6 +21,8 @@ def make_classification(n_samples=1000, n_features=100, n_informative=2, scale=1
         Scale the true coefficient array by this
     chunksize : int
         Number of rows per dask array block.
+    is_sparse: bool
+        Return a sparse matrix
 
     Returns
     -------
@@ -37,6 +40,8 @@ def make_classification(n_samples=1000, n_features=100, n_informative=2, scale=1
     """
     X = da.random.normal(0, 1, size=(n_samples, n_features),
                          chunks=(chunksize, n_features))
+    if is_sparse:
+        X = X.map_blocks(sparse.COO)
     informative_idx = np.random.choice(n_features, n_informative)
     beta = (np.random.random(n_features) - 1) * scale
     z0 = X[:, informative_idx].dot(beta[informative_idx])
@@ -45,7 +50,7 @@ def make_classification(n_samples=1000, n_features=100, n_informative=2, scale=1
 
 
 def make_regression(n_samples=1000, n_features=100, n_informative=2, scale=1.0,
-                    chunksize=100):
+                    chunksize=100, is_sparse=False):
     """
     Generate a dummy dataset for regression tasks.
 
@@ -61,6 +66,8 @@ def make_regression(n_samples=1000, n_features=100, n_informative=2, scale=1.0,
         Scale the true coefficient array by this
     chunksize : int
         Number of rows per dask array block.
+    is_sparse: bool
+        Return a sparse matrix
 
     Returns
     -------
@@ -78,6 +85,8 @@ def make_regression(n_samples=1000, n_features=100, n_informative=2, scale=1.0,
     """
     X = da.random.normal(0, 1, size=(n_samples, n_features),
                          chunks=(chunksize, n_features))
+    if is_sparse:
+        X = X.map_blocks(sparse.COO)
     informative_idx = np.random.choice(n_features, n_informative)
     beta = (np.random.random(n_features) - 1) * scale
     z0 = X[:, informative_idx].dot(beta[informative_idx])
@@ -86,7 +95,7 @@ def make_regression(n_samples=1000, n_features=100, n_informative=2, scale=1.0,
 
 
 def make_poisson(n_samples=1000, n_features=100, n_informative=2, scale=1.0,
-                 chunksize=100):
+                 chunksize=100, is_sparse=False):
     """
     Generate a dummy dataset for modeling count data.
 
@@ -102,6 +111,8 @@ def make_poisson(n_samples=1000, n_features=100, n_informative=2, scale=1.0,
         Scale the true coefficient array by this
     chunksize : int
         Number of rows per dask array block.
+    is_sparse: bool
+        Return a sparse matrix
 
     Returns
     -------
@@ -119,6 +130,8 @@ def make_poisson(n_samples=1000, n_features=100, n_informative=2, scale=1.0,
     """
     X = da.random.normal(0, 1, size=(n_samples, n_features),
                          chunks=(chunksize, n_features))
+    if is_sparse:
+        X = X.map_blocks(sparse.COO)
     informative_idx = np.random.choice(n_features, n_informative)
     beta = (np.random.random(n_features) - 1) * scale
     z0 = X[:, informative_idx].dot(beta[informative_idx])

--- a/dask_glm/estimators.py
+++ b/dask_glm/estimators.py
@@ -6,8 +6,8 @@ from sklearn.base import BaseEstimator
 from . import algorithms
 from . import families
 from .utils import (
-    sigmoid, dot, add_intercept, mean_squared_error, accuracy_score, exp,
-    poisson_deviance
+    sigmoid, dot, add_intercept, add_sparse_intercept, mean_squared_error,
+    accuracy_score, exp, poisson_deviance
 )
 
 
@@ -32,7 +32,7 @@ class _GLM(BaseEstimator):
 
     def __init__(self, fit_intercept=True, solver='admm', regularizer='l2',
                  max_iter=100, tol=1e-4, lamduh=1.0, rho=1,
-                 over_relax=1, abstol=1e-4, reltol=1e-2):
+                 over_relax=1, abstol=1e-4, reltol=1e-2, use_sparse_matrix=False):
         self.fit_intercept = fit_intercept
         self.solver = solver
         self.regularizer = regularizer
@@ -43,6 +43,7 @@ class _GLM(BaseEstimator):
         self.over_relax = over_relax
         self.abstol = abstol
         self.reltol = reltol
+        self.use_sparse_matrix = use_sparse_matrix
 
         self.coef_ = None
         self.intercept_ = None
@@ -60,6 +61,9 @@ class _GLM(BaseEstimator):
             fit_kwargs.update({'regularizer', 'lamduh'})
 
         self._fit_kwargs = {k: getattr(self, k) for k in fit_kwargs}
+        if use_sparse_matrix:
+            # Normalize a sparse matrix will densify it. Disable the feature
+            self._fit_kwargs['normalize'] = False
 
     def fit(self, X, y=None):
         X_ = self._maybe_add_intercept(X)
@@ -74,7 +78,10 @@ class _GLM(BaseEstimator):
 
     def _maybe_add_intercept(self, X):
         if self.fit_intercept:
-            return add_intercept(X)
+            if self.use_sparse_matrix:
+                return add_sparse_intercept(X)
+            else:
+                return add_intercept(X)
         else:
             return X
 

--- a/dask_glm/tests/test_algos_families.py
+++ b/dask_glm/tests/test_algos_families.py
@@ -42,7 +42,7 @@ def make_intercept_data(N, p, seed=20009):
                          [lbfgs,
                           newton,
                           gradient_descent])
-@pytest.mark.parametrize('N, p, seed',
+@pytest.mark.parametrize('N, p, seed,',
                          [(100, 2, 20009),
                           (250, 12, 90210),
                           (95, 6, 70605)])

--- a/dask_glm/tests/test_estimators.py
+++ b/dask_glm/tests/test_estimators.py
@@ -47,7 +47,7 @@ def test_pr_init(solver):
 @pytest.mark.parametrize('is_sparse', [True, False])
 def test_fit(fit_intercept, is_sparse):
     X, y = make_classification(n_samples=100, n_features=5, chunksize=10, is_sparse=is_sparse)
-    lr = LogisticRegression(fit_intercept=fit_intercept, use_sparse_matrix=is_sparse)
+    lr = LogisticRegression(fit_intercept=fit_intercept)
     lr.fit(X, y)
     lr.predict(X)
     lr.predict_proba(X)
@@ -57,7 +57,7 @@ def test_fit(fit_intercept, is_sparse):
 @pytest.mark.parametrize('is_sparse', [True, False])
 def test_lm(fit_intercept, is_sparse):
     X, y = make_regression(n_samples=100, n_features=5, chunksize=10, is_sparse=is_sparse)
-    lr = LinearRegression(fit_intercept=fit_intercept, use_sparse_matrix=is_sparse)
+    lr = LinearRegression(fit_intercept=fit_intercept)
     lr.fit(X, y)
     lr.predict(X)
     if fit_intercept:
@@ -69,7 +69,7 @@ def test_lm(fit_intercept, is_sparse):
 def test_big(fit_intercept, is_sparse):
     with dask.config.set(scheduler='synchronous'):
         X, y = make_classification(is_sparse=is_sparse)
-        lr = LogisticRegression(fit_intercept=fit_intercept, use_sparse_matrix=is_sparse)
+        lr = LogisticRegression(fit_intercept=fit_intercept)
         lr.fit(X, y)
         lr.predict(X)
         lr.predict_proba(X)
@@ -82,7 +82,7 @@ def test_big(fit_intercept, is_sparse):
 def test_poisson_fit(fit_intercept, is_sparse):
     with dask.config.set(scheduler='synchronous'):
         X, y = make_poisson(is_sparse=is_sparse)
-        pr = PoissonRegression(fit_intercept=fit_intercept, use_sparse_matrix=is_sparse)
+        pr = PoissonRegression(fit_intercept=fit_intercept)
         pr.fit(X, y)
         pr.predict(X)
         pr.get_deviance(X, y)

--- a/dask_glm/tests/test_estimators.py
+++ b/dask_glm/tests/test_estimators.py
@@ -44,18 +44,20 @@ def test_pr_init(solver):
 
 
 @pytest.mark.parametrize('fit_intercept', [True, False])
-def test_fit(fit_intercept):
-    X, y = make_classification(n_samples=100, n_features=5, chunksize=10)
-    lr = LogisticRegression(fit_intercept=fit_intercept)
+@pytest.mark.parametrize('is_sparse', [True, False])
+def test_fit(fit_intercept, is_sparse):
+    X, y = make_classification(n_samples=100, n_features=5, chunksize=10, is_sparse=is_sparse)
+    lr = LogisticRegression(fit_intercept=fit_intercept, use_sparse_matrix=is_sparse)
     lr.fit(X, y)
     lr.predict(X)
     lr.predict_proba(X)
 
 
 @pytest.mark.parametrize('fit_intercept', [True, False])
-def test_lm(fit_intercept):
-    X, y = make_regression(n_samples=100, n_features=5, chunksize=10)
-    lr = LinearRegression(fit_intercept=fit_intercept)
+@pytest.mark.parametrize('is_sparse', [True, False])
+def test_lm(fit_intercept, is_sparse):
+    X, y = make_regression(n_samples=100, n_features=5, chunksize=10, is_sparse=is_sparse)
+    lr = LinearRegression(fit_intercept=fit_intercept, use_sparse_matrix=is_sparse)
     lr.fit(X, y)
     lr.predict(X)
     if fit_intercept:
@@ -63,10 +65,11 @@ def test_lm(fit_intercept):
 
 
 @pytest.mark.parametrize('fit_intercept', [True, False])
-def test_big(fit_intercept):
+@pytest.mark.parametrize('is_sparse', [True, False])
+def test_big(fit_intercept, is_sparse):
     with dask.config.set(scheduler='synchronous'):
-        X, y = make_classification()
-        lr = LogisticRegression(fit_intercept=fit_intercept)
+        X, y = make_classification(is_sparse=is_sparse)
+        lr = LogisticRegression(fit_intercept=fit_intercept, use_sparse_matrix=is_sparse)
         lr.fit(X, y)
         lr.predict(X)
         lr.predict_proba(X)
@@ -75,10 +78,11 @@ def test_big(fit_intercept):
 
 
 @pytest.mark.parametrize('fit_intercept', [True, False])
-def test_poisson_fit(fit_intercept):
+@pytest.mark.parametrize('is_sparse', [True, False])
+def test_poisson_fit(fit_intercept, is_sparse):
     with dask.config.set(scheduler='synchronous'):
-        X, y = make_poisson()
-        pr = PoissonRegression(fit_intercept=fit_intercept)
+        X, y = make_poisson(is_sparse=is_sparse)
+        pr = PoissonRegression(fit_intercept=fit_intercept, use_sparse_matrix=is_sparse)
         pr.fit(X, y)
         pr.predict(X)
         pr.get_deviance(X, y)

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -72,8 +72,9 @@ def test_add_intercept_dask():
 
 
 def test_add_intercept_sparse():
+    from sparse.utils import assert_eq
     X = sparse.COO(np.zeros((4, 4)))
-    result = utils.add_sparse_intercept(X)
+    result = utils.add_intercept(X)
     expected = sparse.COO(np.array([
         [0, 0, 0, 0, 1],
         [0, 0, 0, 0, 1],
@@ -85,7 +86,7 @@ def test_add_intercept_sparse():
 
 def test_add_intercept_sparse_dask():
     X = da.from_array(sparse.COO(np.zeros((4, 4))), chunks=(2, 4))
-    result = utils.add_sparse_intercept(X)
+    result = utils.add_intercept(X)
     expected = da.from_array(sparse.COO(np.array([
         [0, 0, 0, 0, 1],
         [0, 0, 0, 0, 1],
@@ -96,7 +97,6 @@ def test_add_intercept_sparse_dask():
 
 
 def test_sparse():
-    sparse = pytest.importorskip('sparse')
     from sparse.utils import assert_eq
     x = sparse.COO({(0, 0): 1, (1, 2): 2, (2, 1): 3})
     y = x.todense()

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -72,7 +72,6 @@ def test_add_intercept_dask():
 
 
 def test_add_intercept_sparse():
-    from sparse._utils import assert_eq
     X = sparse.COO(np.zeros((4, 4)))
     result = utils.add_intercept(X)
     expected = sparse.COO(np.array([
@@ -81,7 +80,7 @@ def test_add_intercept_sparse():
         [0, 0, 0, 0, 1],
         [0, 0, 0, 0, 1],
     ], dtype=X.dtype))
-    assert_eq(result, expected)
+    assert (result == expected).all()
 
 
 def test_add_intercept_sparse_dask():
@@ -97,9 +96,15 @@ def test_add_intercept_sparse_dask():
 
 
 def test_sparse():
-    from sparse._utils import assert_eq
     x = sparse.COO({(0, 0): 1, (1, 2): 2, (2, 1): 3})
     y = x.todense()
     assert utils.sum(x) == utils.sum(x.todense())
     for func in [utils.sigmoid, utils.sum, utils.exp]:
-        assert_eq(func(x), func(y))
+        assert (func(x) == func(y)).all()
+
+
+def test_dask_array_is_sparse():
+    assert utils.is_dask_array_sparse(da.from_array(
+        sparse.COO([], [], shape=(10, 10))))
+    assert utils.is_dask_array_sparse(da.from_array(sparse.eye(10)))
+    assert not utils.is_dask_array_sparse(da.from_array(np.eye(10)))

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -108,3 +108,8 @@ def test_dask_array_is_sparse():
         sparse.COO([], [], shape=(10, 10))))
     assert utils.is_dask_array_sparse(da.from_array(sparse.eye(10)))
     assert not utils.is_dask_array_sparse(da.from_array(np.eye(10)))
+
+
+@pytest.mark.xfail(reason="dask does not forward DOK in _meta (https://github.com/pydata/sparse/issues/292)")
+def test_dok_dask_array_is_sparse():
+    assert utils.is_dask_array_sparse(da.from_array(sparse.DOK((10, 10))))

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 import dask.array as da
+import sparse
 
 from dask_glm import utils
 from dask.array.utils import assert_eq
@@ -67,6 +68,30 @@ def test_add_intercept_dask():
         [0, 0, 0, 0, 1],
         [0, 0, 0, 0, 1],
     ], dtype=X.dtype), chunks=2)
+    assert_eq(result, expected)
+
+
+def test_add_intercept_sparse():
+    X = sparse.COO(np.zeros((4, 4)))
+    result = utils.add_sparse_intercept(X)
+    expected = sparse.COO(np.array([
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+    ], dtype=X.dtype))
+    assert_eq(result, expected)
+
+
+def test_add_intercept_sparse_dask():
+    X = da.from_array(sparse.COO(np.zeros((4, 4))), chunks=(2, 4))
+    result = utils.add_sparse_intercept(X)
+    expected = da.from_array(sparse.COO(np.array([
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+    ], dtype=X.dtype)), chunks=2)
     assert_eq(result, expected)
 
 

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -110,6 +110,7 @@ def test_dask_array_is_sparse():
     assert not utils.is_dask_array_sparse(da.from_array(np.eye(10)))
 
 
-@pytest.mark.xfail(reason="dask does not forward DOK in _meta (https://github.com/pydata/sparse/issues/292)")
+@pytest.mark.xfail(reason="dask does not forward DOK in _meta "
+                          "(https://github.com/pydata/sparse/issues/292)")
 def test_dok_dask_array_is_sparse():
     assert utils.is_dask_array_sparse(da.from_array(sparse.DOK((10, 10))))

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -72,7 +72,7 @@ def test_add_intercept_dask():
 
 
 def test_add_intercept_sparse():
-    from sparse.utils import assert_eq
+    from sparse._utils import assert_eq
     X = sparse.COO(np.zeros((4, 4)))
     result = utils.add_intercept(X)
     expected = sparse.COO(np.array([
@@ -97,7 +97,7 @@ def test_add_intercept_sparse_dask():
 
 
 def test_sparse():
-    from sparse.utils import assert_eq
+    from sparse._utils import assert_eq
     x = sparse.COO({(0, 0): 1, (1, 2): 2, (2, 1): 3})
     y = x.todense()
     assert utils.sum(x) == utils.sum(x.todense())

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -150,7 +150,7 @@ def add_intercept(X):
     return np.concatenate([X, np.ones((X.shape[0], 1))], axis=1)
 
 
-@dispatch((sparse.COO, sparse.DOK))
+@dispatch(sparse.SparseArray)
 def add_intercept(X):
     return sparse.concatenate([X, sparse.COO(np.ones((X.shape[0], 1)))], axis=1)
 

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -142,7 +142,7 @@ def is_dask_array_sparse(X):
     """
     Check using _meta if a dask array contains sparse arrays
     """
-    return isinstance(X._meta, sparse.COO) or isinstance(X._meta, sparse.DOK)
+    return isinstance(X._meta, sparse.SparseArray)
 
 
 @dispatch(np.ndarray)

--- a/environment.yml
+++ b/environment.yml
@@ -26,3 +26,4 @@ dependencies:
   - py==1.4.32
   - pytest==3.0.6
   - scipy==0.18.1
+  - sparse==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ multipledispatch>=0.4.9
 scipy>=0.18.1
 scikit-learn>=0.18
 distributed
+sparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ multipledispatch>=0.4.9
 scipy>=0.18.1
 scikit-learn>=0.18
 distributed
-sparse
+sparse>=0.7.0


### PR DESCRIPTION
This commit enable to give sparse matrix (from this lib https://github.com/pydata/sparse/) to the dask-glm estimators

It is linked to this "epic" ticket: https://github.com/dask/dask-ml/issues/123

The changes are:
* Fit intersect handle sparse matrix
* Add option to inject if estimator can manage sparse matrix

Some remarks about the choices:
* I don't know how to detect dynamically if a dask array is sparse. A solution could be to compute 1 task and check the resulting array... It will trigger unnecessary computations. That's why, I decided to pass an option to tell to estimators that matrix will be sparse. 
* normalize will densify the matrix (and raise a Exception in sparse library code). I decided to disable the option when matrix are sparse.
* sparse prevents to mix sparse and dense matrix in concatenate. So I specialized add_intersecept for sparse matrix.