### PR TITLE
Fix the util function "scatter_array" to support both numpy and cupy

### DIFF
--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -217,7 +217,8 @@ def scatter_array(arr, dask_client):
     Return the equivalent dask array
     """
     future_arr = dask_client.scatter(arr)
-    return da.from_delayed(future_arr, shape=arr.shape, dtype=arr.dtype)
+    return da.from_delayed(future_arr, shape=arr.shape, dtype=arr.dtype,
+                           meta=np.zeros_like(arr, shape=()))
 
 
 def get_distributed_client():


### PR DESCRIPTION
The current implementation of `dask_glm.utils.scatter_array` always returns a dask array with chunk type `numpy.ndarray` even when the input array is a cupy array. By providing the `meta` argument for `from_delayed`, the returned chunk type matches the input array. No `import cupy` for this PR.