### PR TITLE
Fix and clean dask-glm.utils.dot for cupy and sparse input

### DIFF
--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -116,15 +116,9 @@ def test_dok_dask_array_is_sparse():
     assert utils.is_dask_array_sparse(da.from_array(sparse.DOK((10, 10))))
 
 
-try:
-    import cupy
-    has_cupy = True
-except ImportError:
-    has_cupy = False
-
-
-@pytest.mark.skipif(not has_cupy, reason="requires cupy")
 def test_dot_with_cupy():
+    cupy = pytest.importorskip('cupy')
+
     # dot(cupy.array, cupy.array)
     A = cupy.random.rand(100, 100)
     B = cupy.random.rand(100)

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -122,38 +122,34 @@ def test_dot_with_cupy():
     # dot(cupy.array, cupy.array)
     A = cupy.random.rand(100, 100)
     B = cupy.random.rand(100)
-    res_cupy = utils.dot(A, B)
-    res_numpy = utils.dot(A.get(), B.get())
-    assert_eq(res_cupy.get(), res_numpy)
+    ans = cupy.dot(A, B)
+    res = utils.dot(A, B)
+    assert_eq(ans, res)
 
     # dot(dask.array, cupy.array)
     dA = da.from_array(A, chunks=(10, 100))
-    res_cupy = utils.dot(dA, B)
-    dA_numpy = dA.map_blocks(lambda x: x.get(), dtype=dA.dtype)
-    res_numpy = utils.dot(dA_numpy, B.get())
-    assert_eq(res_cupy.compute().get(), res_numpy.compute())
+    res = utils.dot(dA, B).compute()
+    assert_eq(ans, res)
 
     # dot(cupy.array, dask.array)
     dB = da.from_array(B, chunks=(10))
-    res_cupy = utils.dot(A, dB)
-    dB_numpy = dB.map_blocks(lambda x: x.get(), dtype=dA.dtype)
-    res_numpy = utils.dot(A.get(), dB_numpy)
-    assert_eq(res_cupy.compute().get(), res_numpy.compute())
+    res = utils.dot(A, dB).compute()
+    assert_eq(ans, res)
 
 
 def test_dot_with_sparse():
     A = sparse.random((1024, 64))
     B = sparse.random((64))
     ans = sparse.dot(A, B)
-   
+
     # dot(sparse.array, sparse.array)
     res = utils.dot(A, B)
     assert_eq(ans, res)
-    
+
     # dot(sparse.array, dask.array)
     res = utils.dot(A, da.from_array(B, chunks=B.shape))
     assert_eq(ans, res.compute())
 
     # dot(sparse.array, dask.array)
     res = utils.dot(da.from_array(A, chunks=A.shape), B)
-    assert_eq(ans, res.compute()) 
+    assert_eq(ans, res.compute())

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -139,3 +139,21 @@ def test_dot_with_cupy():
     dB_numpy = dB.map_blocks(lambda x: x.get(), dtype=dA.dtype)
     res_numpy = utils.dot(A.get(), dB_numpy)
     assert_eq(res_cupy.compute().get(), res_numpy.compute())
+
+
+def test_dot_with_sparse():
+    A = sparse.random((1024, 64))
+    B = sparse.random((64))
+    ans = sparse.dot(A, B)
+   
+    # dot(sparse.array, sparse.array)
+    res = utils.dot(A, B)
+    assert_eq(ans, res)
+    
+    # dot(sparse.array, dask.array)
+    res = utils.dot(A, da.from_array(B, chunks=B.shape))
+    assert_eq(ans, res.compute())
+
+    # dot(sparse.array, dask.array)
+    res = utils.dot(da.from_array(A, chunks=A.shape), B)
+    assert_eq(ans, res.compute()) 

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -150,6 +150,6 @@ def test_dot_with_sparse():
     res = utils.dot(A, da.from_array(B, chunks=B.shape))
     assert_eq(ans, res.compute())
 
-    # dot(sparse.array, dask.array)
+    # dot(dask.array, sparse.array)
     res = utils.dot(da.from_array(A, chunks=A.shape), B)
     assert_eq(ans, res.compute())

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -104,18 +104,11 @@ def log1p(A):
     return da.log1p(A)
 
 
-def _to_dask_array(x):
-    if isinstance(x, da.Array):
-        return x
-    else:
-        return da.from_array(x, chunks=x.shape)
-
-
 @dispatch(object, object)
 def dot(A, B):
     if isinstance(A, da.Array) or isinstance(B, da.Array):
-        A = _to_dask_array(A)
-        B = _to_dask_array(B)
+        A = da.asarray(A, chunks=A.shape)
+        B = da.asarray(B, chunks=B.shape)
     return np.dot(A, B)
 
 

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -106,9 +106,17 @@ def log1p(A):
 
 @dispatch(object, object)
 def dot(A, B):
-    x = max([A, B], key=lambda x: getattr(x, '__array_priority__', 0))
-    module = package_of(x)
-    return module.dot(A, B)
+    if isinstance(A, da.Array) and "cupy" in str(type(B)):
+        return A.dot(B)
+    elif "cupy" in str(type(A)) and "cupy" in str(type(B)):
+        return A.dot(B)
+    elif "cupy" in str(type(A)) and isinstance(B, da.Array):
+        A = da.from_array(A, chunks=A.shape)
+        return da.dot(A, B)
+    else:
+        x = max([A, B], key=lambda x: getattr(x, '__array_priority__', 0))
+        module = package_of(x)
+        return module.dot(A, B)
 
 
 @dispatch(da.Array, np.ndarray)

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -107,7 +107,8 @@ def log1p(A):
 @dispatch(object, object)
 def dot(A, B):
     if isinstance(A, da.Array) and "cupy" in str(type(B)):
-        return A.dot(B)
+        B = da.from_array(B, chunks=B.shape)
+        return da.dot(A, B)
     elif "cupy" in str(type(A)) and "cupy" in str(type(B)):
         return A.dot(B)
     elif "cupy" in str(type(A)) and isinstance(B, da.Array):


### PR DESCRIPTION
Edit: The original `dask-glm.utils.dot` doesn't work for `cupy` inputs. It doesn't work for `dot(sparse.array, dask.array)` either because `sparse.dot` is invoked and it isn't able to handle Dask arrays. Please find details below and in the threads.

In the original code of `dask_glm.utils.dot`, errors occur when `A` or `B` is a `cupy` array.
https://github.com/dask/dask-glm/blob/9eab0c277741f0a20b7f282a80519c7fb0fde1cd/dask_glm/utils.py#L107-L111

This is due to:
1. `package_of(x)` returns `None` if `x` is a `cupy` array.
2. Even if `package_of(x)` returns `cupy`, `x.__array_priority__` is 100  if `x` is a `cupy` array, which is greater than 10 of a `dask` array. So `cupy.dot(cupy.array, dask.array)` will be invoked and result in error.

This PR supports the follow calculation for `dask_glm.utils.dot` with `cupy` inputs:

1. `dot(cupy.array, cupy.array)`
2. `dot(cupy.array, dask.array with cupy chunks)`
3. `dot(dask.array with cupy chunks, cupy.array)`

`cupy` is not imported in this implementation. And a new test with `pytest.importorskip` is added to `dask_glm/tests/test_utils.py`.