### PR TITLE
[Review] Allow lbfgs and admm with dask cupy inputs

### DIFF
--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -25,8 +25,8 @@ def compute_stepsize_dask(beta, step, Xbeta, Xstep, y, curr_val,
     ----------
     beta : array-like
     step : float
-    XBeta : array-lie
-    Xstep :
+    XBeta : array-like
+    Xstep : float
     y : array-like
     curr_val : float
     famlily : Family, optional
@@ -36,7 +36,7 @@ def compute_stepsize_dask(beta, step, Xbeta, Xstep, y, curr_val,
 
     Returns
     -------
-    stepSize : flaot
+    stepSize : float
     beta : array-like
     xBeta : array-like
     func : callable
@@ -141,7 +141,7 @@ def gradient_descent(X, y, max_iter=100, tol=1e-14, family=Logistic, **kwargs):
 
 @normalize
 def newton(X, y, max_iter=50, tol=1e-8, family=Logistic, **kwargs):
-    """Newtons Method for Logistic Regression.
+    """Newton's Method for Logistic Regression.
 
     Parameters
     ----------
@@ -205,7 +205,7 @@ def admm(X, y, regularizer='l1', lamduh=0.1, rho=1, over_relax=1,
     X : array-like, shape (n_samples, n_features)
     y : array-like, shape (n_samples,)
     regularizer : str or Regularizer
-    lambuh : float
+    lamduh : float
     rho : float
     over_relax : FLOAT
     max_iter : int
@@ -311,6 +311,8 @@ def lbfgs(X, y, regularizer=None, lamduh=1.0, max_iter=100, tol=1e-4,
     ----------
     X : array-like, shape (n_samples, n_features)
     y : array-like, shape (n_samples,)
+    regularizer : str or Regularizer
+    lamduh : float
     max_iter : int
         maximum number of iterations to attempt before declaring
         failure to converge
@@ -318,6 +320,8 @@ def lbfgs(X, y, regularizer=None, lamduh=1.0, max_iter=100, tol=1e-4,
         Maximum allowed change from prior iteration required to
         declare convergence
     family : Family
+    verbose : bool, default False
+        whether to print diagnostic information during convergence
 
     Returns
     -------
@@ -352,11 +356,14 @@ def lbfgs(X, y, regularizer=None, lamduh=1.0, max_iter=100, tol=1e-4,
 def proximal_grad(X, y, regularizer='l1', lamduh=0.1, family=Logistic,
                   max_iter=100, tol=1e-8, **kwargs):
     """
+    Proximal Gradient Method
 
     Parameters
     ----------
     X : array-like, shape (n_samples, n_features)
     y : array-like, shape (n_samples,)
+    regularizer : str or Regularizer
+    lamduh : float
     max_iter : int
         maximum number of iterations to attempt before declaring
         failure to converge
@@ -364,8 +371,6 @@ def proximal_grad(X, y, regularizer='l1', lamduh=0.1, family=Logistic,
         Maximum allowed change from prior iteration required to
         declare convergence
     family : Family
-    verbose : bool, default False
-        whether to print diagnostic information during convergence
 
     Returns
     -------

--- a/dask_glm/estimators.py
+++ b/dask_glm/estimators.py
@@ -14,7 +14,7 @@ from .utils import (
 class _GLM(BaseEstimator):
     """ Base estimator for Generalized Linear Models
 
-    You should not use this class directly, you should use on of its subclasses
+    You should not use this class directly, you should use one of its subclasses
     instead.
 
     This class should be subclassed and paired with a GLM Family object like
@@ -81,7 +81,7 @@ class _GLM(BaseEstimator):
 
 class LogisticRegression(_GLM):
     """
-    Esimator for logistic regression.
+    Estimator for logistic regression.
 
     Parameters
     ----------
@@ -135,7 +135,7 @@ class LogisticRegression(_GLM):
 
 class LinearRegression(_GLM):
     """
-    Esimator for a linear model using Ordinary Least Squares.
+    Estimator for a linear model using Ordinary Least Squares.
 
     Parameters
     ----------
@@ -185,7 +185,7 @@ class LinearRegression(_GLM):
 
 class PoissonRegression(_GLM):
     """
-    Esimator for Poisson Regression.
+    Estimator for Poisson Regression.
 
     Parameters
     ----------

--- a/dask_glm/tests/test_admm.py
+++ b/dask_glm/tests/test_admm.py
@@ -7,7 +7,7 @@ import numpy as np
 from dask_glm.algorithms import admm, local_update
 from dask_glm.families import Logistic, Normal
 from dask_glm.regularizers import L1
-from dask_glm.utils import make_y
+from dask_glm.utils import make_y, to_dask_cupy_array_xy
 
 
 @pytest.mark.parametrize('N', [1000, 10000])
@@ -54,10 +54,8 @@ def test_admm_with_large_lamduh(N, p, nchunks, is_cupy):
 
     if is_cupy:
         cupy = pytest.importorskip('cupy')
-        X = X.map_blocks(lambda x: cupy.asarray(x),
-                         dtype=X.dtype, meta=cupy.asarray(X._meta))
-        y = y.map_blocks(lambda x: cupy.asarray(x),
-                         dtype=y.dtype, meta=cupy.asarray(y._meta))
+        X, y = to_dask_cupy_array_xy(X, y, cupy)
+
     X, y = persist(X, y)
     z = admm(X, y, regularizer=L1(), lamduh=1e5, rho=20, max_iter=500)
 

--- a/dask_glm/tests/test_estimators.py
+++ b/dask_glm/tests/test_estimators.py
@@ -4,6 +4,7 @@ import dask
 from dask_glm.estimators import LogisticRegression, LinearRegression, PoissonRegression
 from dask_glm.datasets import make_classification, make_regression, make_poisson
 from dask_glm.regularizers import Regularizer
+from dask_glm.utils import to_dask_cupy_array_xy
 
 
 @pytest.fixture(params=[r() for r in Regularizer.__subclasses__()])
@@ -53,10 +54,7 @@ def test_fit(fit_intercept, is_sparse, is_cupy):
 
     if is_cupy and not is_sparse:
         cupy = pytest.importorskip('cupy')
-        X = X.map_blocks(lambda x: cupy.asarray(x),
-                         dtype=X.dtype, meta=cupy.asarray(X._meta))
-        y = y.map_blocks(lambda x: cupy.asarray(x),
-                         dtype=y.dtype, meta=cupy.asarray(y._meta))
+        X, y = to_dask_cupy_array_xy(X, y, cupy)
 
     lr = LogisticRegression(fit_intercept=fit_intercept)
     lr.fit(X, y)
@@ -73,10 +71,7 @@ def test_lm(fit_intercept, is_sparse, is_cupy):
     X, y = make_regression(n_samples=100, n_features=5, chunksize=10, is_sparse=is_sparse)
     if is_cupy and not is_sparse:
         cupy = pytest.importorskip('cupy')
-        X = X.map_blocks(lambda x: cupy.asarray(x),
-                         dtype=X.dtype, meta=cupy.asarray(X._meta))
-        y = y.map_blocks(lambda x: cupy.asarray(x),
-                         dtype=y.dtype, meta=cupy.asarray(y._meta))
+        X, y = to_dask_cupy_array_xy(X, y, cupy)
     lr = LinearRegression(fit_intercept=fit_intercept)
     lr.fit(X, y)
     lr.predict(X)
@@ -94,10 +89,7 @@ def test_big(fit_intercept, is_sparse, is_cupy):
         X, y = make_classification(is_sparse=is_sparse)
         if is_cupy and not is_sparse:
             cupy = pytest.importorskip('cupy')
-            X = X.map_blocks(lambda x: cupy.asarray(x),
-                             dtype=X.dtype, meta=cupy.asarray(X._meta))
-            y = y.map_blocks(lambda x: cupy.asarray(x),
-                             dtype=y.dtype, meta=cupy.asarray(y._meta))
+            X, y = to_dask_cupy_array_xy(X, y, cupy)
         lr = LogisticRegression(fit_intercept=fit_intercept)
         lr.fit(X, y)
         lr.predict(X)
@@ -116,10 +108,7 @@ def test_poisson_fit(fit_intercept, is_sparse, is_cupy):
         X, y = make_poisson(is_sparse=is_sparse)
         if is_cupy and not is_sparse:
             cupy = pytest.importorskip('cupy')
-            X = X.map_blocks(lambda x: cupy.asarray(x),
-                             dtype=X.dtype, meta=cupy.asarray(X._meta))
-            y = y.map_blocks(lambda x: cupy.asarray(x),
-                             dtype=y.dtype, meta=cupy.asarray(y._meta))
+            X, y = to_dask_cupy_array_xy(X, y, cupy)
         pr = PoissonRegression(fit_intercept=fit_intercept)
         pr.fit(X, y)
         pr.predict(X)

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -216,3 +216,14 @@ def maybe_to_cupy(beta, X):
         import cupy
         return cupy.asarray(beta)
     return beta
+
+
+def to_dask_cupy_array(X, cupy):
+    """ convert a dask numpy array to a dask cupy array
+    """
+    return X.map_blocks(lambda x: cupy.asarray(x),
+                        dtype=X.dtype, meta=cupy.asarray(X._meta))
+
+
+def to_dask_cupy_array_xy(X, y, cupy):
+    return dask_array_to_cupy(X, cupy), dask_array_to_cupy(y, cupy)

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -226,4 +226,4 @@ def to_dask_cupy_array(X, cupy):
 
 
 def to_dask_cupy_array_xy(X, y, cupy):
-    return dask_array_to_cupy(X, cupy), dask_array_to_cupy(y, cupy)
+    return to_dask_cupy_array(X, cupy), to_dask_cupy_array(y, cupy)


### PR DESCRIPTION
This PR allows `lbfgs` solver to accept `cupy` inputs. The main changes are:

-  converting `numpy` array, `beta`, to `cupy` array to accelerate `pointwise_loss` and `pointwise_gradient`

-  converting `cupy` arrays, `loss` and `gradients`, to `numpy` arrays to utilize `scipy.optimize.fmin_l_bfgs_b`

Similar changes are made to add `cupy` support to `admm`.

`dask cupy tests` are added for all 5 solvers.