### PR TITLE
[WIP] Allow numpy array (not dask array) as inputs

### DIFF
--- a/dask_glm/algorithms.py
+++ b/dask_glm/algorithms.py
@@ -11,7 +11,7 @@ import dask.array as da
 from scipy.optimize import fmin_l_bfgs_b
 
 
-from dask_glm.utils import dot, normalize, scatter_array, get_distributed_client
+from dask_glm.utils import dot, normalize, scatter_array, get_distributed_client, safe_zeros_like
 from dask_glm.families import Logistic
 from dask_glm.regularizers import Regularizer
 
@@ -97,7 +97,7 @@ def gradient_descent(X, y, max_iter=100, tol=1e-14, family=Logistic, **kwargs):
     stepSize = 1.0
     recalcRate = 10
     backtrackMult = firstBacktrackMult
-    beta = np.zeros_like(X._meta, shape=p)
+    beta = safe_zeros_like(X, shape=p)
 
     for k in range(max_iter):
         # how necessary is this recalculation?
@@ -161,7 +161,7 @@ def newton(X, y, max_iter=50, tol=1e-8, family=Logistic, **kwargs):
     """
     gradient, hessian = family.gradient, family.hessian
     n, p = X.shape
-    beta = np.zeros_like(X._meta, shape=p)
+    beta = safe_zeros_like(X, shape=p)
     Xbeta = dot(X, beta)
 
     iter_count = 0
@@ -387,7 +387,7 @@ def proximal_grad(X, y, regularizer='l1', lamduh=0.1, family=Logistic,
     stepSize = 1.0
     recalcRate = 10
     backtrackMult = firstBacktrackMult
-    beta = np.zeros_like(X._meta, shape=p)
+    beta = safe_zeros_like(X, shape=p)
     regularizer = Regularizer.get(regularizer)
 
     for k in range(max_iter):

--- a/dask_glm/tests/test_estimators.py
+++ b/dask_glm/tests/test_estimators.py
@@ -44,13 +44,13 @@ def test_pr_init(solver):
 
 
 @pytest.mark.parametrize('fit_intercept', [True, False])
-@pytest.mark.parametrize('is_sparse', [True, False])
-@pytest.mark.parametrize('is_numpy', [True, False])
+@pytest.mark.parametrize('is_sparse,is_numpy', [
+                         (True, False),
+                         (False, False),
+                         (False, True)])
 def test_fit(fit_intercept, is_sparse, is_numpy):
     X, y = make_classification(n_samples=100, n_features=5, chunksize=10, is_sparse=is_sparse)
     if is_numpy:
-        if is_sparse:
-            return
         X, y = dask.compute(X, y)
     lr = LogisticRegression(fit_intercept=fit_intercept)
     lr.fit(X, y)

--- a/dask_glm/tests/test_estimators.py
+++ b/dask_glm/tests/test_estimators.py
@@ -45,8 +45,13 @@ def test_pr_init(solver):
 
 @pytest.mark.parametrize('fit_intercept', [True, False])
 @pytest.mark.parametrize('is_sparse', [True, False])
-def test_fit(fit_intercept, is_sparse):
+@pytest.mark.parametrize('is_numpy', [True, False])
+def test_fit(fit_intercept, is_sparse, is_numpy):
     X, y = make_classification(n_samples=100, n_features=5, chunksize=10, is_sparse=is_sparse)
+    if is_numpy:
+        if is_sparse:
+            return
+        X, y = dask.compute(X, y)
     lr = LogisticRegression(fit_intercept=fit_intercept)
     lr.fit(X, y)
     lr.predict(X)

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -121,7 +121,7 @@ def is_dask_array_sparse(X):
     """
     Check using _meta if a dask array contains sparse arrays
     """
-    return isinstance(X._meta, sparse.SparseArray)
+    return isinstance(X, da.Array) and isinstance(X._meta, sparse.SparseArray)
 
 
 @dispatch(np.ndarray)


### PR DESCRIPTION
Currently `dask_glm.estimators` only accepts `dask.array` as inputs due to this line and other places where `._meta` is accessed without checking the data type.

https://github.com/dask/dask-glm/blob/7b2f85fe043eb29212755e67e33e3df553ed0e58/dask_glm/estimators.py#L67

Is `dask_glm.algorithms` used outside `dask_glm.estimators`?

<details>
  <summary>Click to see the example code and error</summary>

Code:
```
from dask_glm.estimators import LogisticRegression
import numpy
x = numpy.random.rand(10,4)
y = numpy.random.rand(10)

lr = LogisticRegression()
lr.fit(x,y)
```
Error:
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-14-e644bf405118> in <module>
----> 1 lr.fit(x,y)

~/rapids/daskml_cupy/dask-glm/dask_glm/estimators.py in fit(self, X, y)
     65         X_ = self._maybe_add_intercept(X)
     66         fit_kwargs = dict(self._fit_kwargs)
---> 67         if is_dask_array_sparse(X):
     68             fit_kwargs['normalize'] = False
     69 

~/rapids/daskml_cupy/dask-glm/dask_glm/utils.py in is_dask_array_sparse(X)
    122     Check using _meta if a dask array contains sparse arrays
    123     """
--> 124     return isinstance(X._meta, sparse.SparseArray)
    125 
    126 

AttributeError: 'numpy.ndarray' object has no attribute '_meta'
```
  

</details>

This PR allows numpy arrays (not dask numpy array) as input directly. 